### PR TITLE
Transition shorthand

### DIFF
--- a/src/Javis.jl
+++ b/src/Javis.jl
@@ -128,10 +128,17 @@ end
 """
     Translation(p::Union{Point, Symbol})
 
-Create a `Translation(p, p)` such that 
-if there is no animation the start position and end position are the same.
+Create a `Translation(O, p)` such that a translation is done from the origin.
 """
-Translation(p::Union{Point, Symbol}) = Translation(p, p)
+Translation(p::Union{Point, Symbol}) = Translation(O, p)
+
+"""
+    Translation(x::Real, y::Real)
+
+Create a `Translation(O, Point(x,y))` such that a translation is done from the origin.
+Shorthand for writing `Translation(Point(x,y))`.
+"""
+Translation(x::Real, y::Real) = Translation(Point(x, y))
 
 """
     Rotation <: Transition
@@ -152,10 +159,10 @@ end
 """
     Rotation(r::Union{Float64, Symbol})
 
-Rotation as a transition from `r` to itself.
-Can be used as a general non-animating rotation.
+Rotation as a transition from 0.0 to `r` .
+Can be used as a short-hand.
 """
-Rotation(r::Union{Float64, Symbol}) = Rotation(r, r)
+Rotation(r::Union{Float64, Symbol}) = Rotation(0.0, r)
 
 """
     Rotation(r::Union{Float64, Symbol}, center::Union{Point, Symbol})
@@ -180,7 +187,7 @@ We mean the mathematic definition of a continuous line and not a segment of a li
 
 # Fields
 - `p1::Point`: start point
-- `p2::Point`: second point to define the line)
+- `p2::Point`: second point to define the line
 """
 struct Line 
     p1 :: Point

--- a/test/animations.jl
+++ b/test/animations.jl
@@ -35,7 +35,7 @@ end
 
     video = Video(500, 500)
     javis(video, [
-        BackgroundAction(1:25, ground, Rotation(0.0), Translation(Point(25, 25))),
+        BackgroundAction(1:25, ground, Rotation(0.0), Translation(Point(25, 25), Point(25, 25))),
         Action(1:25, latex_title),
         Action(1:25, :red_ball, (args...)->circ(p1, "red"), Rotation(from_rot, to_rot)),
         Action(1:25, :blue_ball, (args...)->circ(p2, "blue"), Rotation(to_rot, from_rot, :red_ball)),
@@ -93,9 +93,9 @@ end
 
     video = Video(500, 500)
     javis(video, [
-        Action(1:25, ground, Rotation(π/2, O), Translation(Point(25,25)); in_global_layer=true),
+        Action(1:25, ground, Rotation(π/2, π/2, O), Translation(Point(25,25), Point(25,25)); in_global_layer=true),
         Action(1:25, latex_title),
-        Action(1:25, :red_ball, (args...)->circ(p1, "red"), Rotation(from_rot, to_rot)),
+        Action(1:25, :red_ball, (args...)->circ(p1, "red"), Rotation(to_rot)),
         Action(1:25, :blue_ball, (args...)->circ(p2, "blue"), Rotation(to_rot, from_rot, :red_ball)),
         Action(1:25, (video, args...)->path!(path_of_red, pos(:red_ball), "red")),
         Action(1:25, (video, args...)->path!(path_of_blue, pos(:blue_ball), "blue")),

--- a/test/animations.jl
+++ b/test/animations.jl
@@ -50,39 +50,6 @@ end
     end
 end
 
-
-@testset "Drawing grid" begin
-    video = Video(500, 500)
-    javis(
-	video,
-	[
-	    Action(1:40, ground),
-	    
-	    Action(1:10, draw_grid(direction = "BL", line_gap = 25)),
-	    Action(1:10, zero_lines(direction = "BL", line_thickness = 10)),
-	    
-	    Action(11:20, draw_grid(direction = "BR", line_gap = 25)),
-	    Action(11:20, zero_lines(direction = "BR", line_thickness = 10)),
-	    
-	    Action(21:30, draw_grid(direction = "TL", line_gap = 25)),
-	    Action(21:30, zero_lines(direction = "TL", line_thickness = 10)),
-	    
-	    Action(31:40, draw_grid(direction = "TR", line_gap = 25)),
-	    Action(31:40, zero_lines(direction = "TR", line_thickness = 10)),
-
-	],
-	tempdirectory = "images"
-    )
-
-    @test_reference "refs/grid_drawing_bl.png" load("images/0000000008.png")
-    @test_reference "refs/grid_drawing_br.png" load("images/0000000018.png")
-    @test_reference "refs/grid_drawing_tl.png" load("images/0000000028.png")
-    @test_reference "refs/grid_drawing_tr.png" load("images/0000000038.png")
-    for i=1:40
-	rm("images/$(lpad(i, 10, "0")).png")
-    end
-end
-
 @testset "Dancing circles layered" begin 
     p1 = Point(100,0)
     p2 = Point(100,80)
@@ -105,6 +72,38 @@ end
     @test_reference "refs/dancing_circles_16_rot_trans.png" load("images/0000000016.png")
     for i=1:25
         rm("images/$(lpad(i, 10, "0")).png")
+    end
+end
+
+@testset "Drawing grid" begin
+    video = Video(500, 500)
+    javis(
+        video,
+        [
+            Action(1:40, ground),
+            
+            Action(1:10, draw_grid(direction = "BL", line_gap = 25)),
+            Action(1:10, zero_lines(direction = "BL", line_thickness = 10)),
+            
+            Action(11:20, draw_grid(direction = "BR", line_gap = 25)),
+            Action(11:20, zero_lines(direction = "BR", line_thickness = 10)),
+            
+            Action(21:30, draw_grid(direction = "TL", line_gap = 25)),
+            Action(21:30, zero_lines(direction = "TL", line_thickness = 10)),
+            
+            Action(31:40, draw_grid(direction = "TR", line_gap = 25)),
+            Action(31:40, zero_lines(direction = "TR", line_thickness = 10)),
+
+        ],
+        tempdirectory = "images"
+    )
+
+    @test_reference "refs/grid_drawing_bl.png" load("images/0000000008.png")
+    @test_reference "refs/grid_drawing_br.png" load("images/0000000018.png")
+    @test_reference "refs/grid_drawing_tl.png" load("images/0000000028.png")
+    @test_reference "refs/grid_drawing_tr.png" load("images/0000000038.png")
+    for i=1:40
+	    rm("images/$(lpad(i, 10, "0")).png")
     end
 end
 

--- a/test/unit.jl
+++ b/test/unit.jl
@@ -21,4 +21,32 @@ end
     Javis.compute_transformation!(action, video, 100)
     @test action.internal_transitions[1].by == Point(100,100)
 end
+
+@testset "translation from origin" begin
+    video = Video(500, 500)
+    # dummy action doesn't need a real function
+    action = Action(1:100, ()->1, Translation(Point(99, 99)))
+    # needs internal translation as well
+    push!(action.internal_transitions, Javis.InternalTranslation(O))
+
+    Javis.compute_transformation!(action, video, 1)
+    @test action.internal_transitions[1].by == O
+    Javis.compute_transformation!(action, video, 50)
+    @test action.internal_transitions[1].by == Point(49,49)
+    Javis.compute_transformation!(action, video, 100)
+    @test action.internal_transitions[1].by == Point(99,99)
+
+    video = Video(500, 500)
+    # dummy action doesn't need a real function
+    action = Action(1:100, ()->1, Translation(99, 99))
+    # needs internal translation as well
+    push!(action.internal_transitions, Javis.InternalTranslation(O))
+
+    Javis.compute_transformation!(action, video, 1)
+    @test action.internal_transitions[1].by == O
+    Javis.compute_transformation!(action, video, 50)
+    @test action.internal_transitions[1].by == Point(49,49)
+    Javis.compute_transformation!(action, video, 100)
+    @test action.internal_transitions[1].by == Point(99,99)
+end
 end


### PR DESCRIPTION
As discussed in #33 we decided to revert `Translation(p)` which mapped to `Translation(p, p)` and now map it to `Translation(O, p)`

Additionally one can now write `Translation(x, y)` such that one does not need to write `Point` every time.