### PR TITLE
downgrade FFMPEG

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ LightXML = "9c8b4983-aa76-5018-a973-4c85ecc9e179"
 Luxor = "ae8d54c2-7ccd-5906-9d76-62fc9837b5bc"
 
 [compat]
-FFMPEG = "0.4"
+FFMPEG = "0.3"
 LaTeXStrings = "1.1"
 LightXML = "0.9"
 Luxor = "2"


### PR DESCRIPTION
FFMPEG v0.3.0 should be good enough and otherwise Plots gets downgraded to a pre v1 version which is probably neither expected nor wanted. Plots.jl has fixed their bounds but hasn't released a new version yet. 