### PR TITLE
Bugfix for allowing id as the first argument

### DIFF
--- a/src/Javis.jl
+++ b/src/Javis.jl
@@ -6,6 +6,8 @@ using LightXML
 using Luxor
 using Random
 
+const FRAMES_SYMBOL = [:same]
+
 """
     Video
 
@@ -125,6 +127,7 @@ Shorthand for Rel(1:i)
 """
 Rel(i::Int) = Rel(1:i)
 
+
 """
     Action(frames, func::Function, args...)
 
@@ -133,6 +136,20 @@ The most simple form of an action (if there are no `args`/`kwargs`) just calls
 `args` are defined it the next function definition and can be seen in action in this example [`javis`](@ref)
 """
 Action(frames, func::Function, args...; kwargs...) = Action(frames, nothing, func, args...; kwargs...)
+
+"""
+    Action(frames_or_id::Symbol, func::Function, args...)
+
+This function decides whether you wrote `Action(frames_symbol, ...)`, or `Action(id_symbol, ...)`
+If the symbol `frames_or_id` is not a `FRAMES_SYMBOL` then it is used as an id_symbol.
+"""
+function Action(frames_or_id::Symbol, func::Function, args...; kwargs...)
+    if frames_or_id in FRAMES_SYMBOL
+        Action(frames_or_id, nothing, func, args...; kwargs...)
+    else
+        Action(:same, frames_or_id, func, args...; kwargs...)
+    end
+end
 
 """
     Action(func::Function, args...)

--- a/test/animations.jl
+++ b/test/animations.jl
@@ -53,7 +53,7 @@ end
         Action(Rel(-24:0), :red_ball, (args...)->circ(p1, "red"), Rotation(from_rot, to_rot)),
         Action(1:25, :blue_ball, (args...)->circ(p2, "blue"), Rotation(to_rot, from_rot, :red_ball)),
         Action(1:25, (video, args...)->path!(path_of_red, get_position(:red_ball), "red")),
-        Action(1:25, (video, args...)->path!(path_of_blue, pos(:blue_ball), "blue")),
+        Action(:same, (video, args...)->path!(path_of_blue, pos(:blue_ball), "blue")),
         Action(1:25, (args...)->rad(pos(:red_ball), pos(:blue_ball), "black"))
     ], tempdirectory="images", pathname="dancing.gif")
 

--- a/test/animations.jl
+++ b/test/animations.jl
@@ -153,7 +153,7 @@ end
     p = Point(100, 0)
     javis(video, [
         Action(1:10, ground),
-        Action(:same, :circ, (args...)->circ_ret_trans(p), Rotation(2π)),
+        Action(:circ, (args...)->circ_ret_trans(p), Rotation(2π)),
         Action((args...)->line(Point(-200, 0), Point(-200, -10*ang(:circ)), :stroke))
     ], tempdirectory="images", pathname="")
 

--- a/test/unit.jl
+++ b/test/unit.jl
@@ -92,7 +92,7 @@ end
     @test_throws ArgumentError Action(Rel(10), (args...)->1, Translation(Point(1,1), Point(100, 100)))
     Action(1:100, (args...)->1, Translation(Point(1,1), Point(100, 100)))
     # throws because :some is not supported as Symbol for `frames`
-    @test_throws ArgumentError Action(:some, (args...)->1, Translation(Point(1,1), Point(100, 100)))    
+    @test_throws ArgumentError Action(:some, :id, (args...)->1, Translation(Point(1,1), Point(100, 100)))    
 end
 
 @testset "Unspecified symbol error" begin


### PR DESCRIPTION
Fix #68

It's now possible to write:
```
javis(video, [
        Action(1:10, ground),
        Action(:circ, (args...)->circ_ret_trans(p), Rotation(2π)),
        Action((args...)->line(Point(-200, 0), Point(-200, -10*ang(:circ)), :stroke))
 ])
```