### PR TITLE
Hotfix for latex docstring

### DIFF
--- a/src/Javis.jl
+++ b/src/Javis.jl
@@ -541,13 +541,15 @@ latex(text::LaTeXString, action::Symbol) = latex(text, 10, action)
     latex(text::LaTeXString, font_size::Real, action::Symbol)
 
 Add the latex string `text` to the top left corner of the LaTeX path.
-Can be added to `Luxor.jl` graphics such as `Video` or `Drawing`.
+Can be added to `Luxor.jl` graphics such as [`Video`](@ref) or [`Drawing`](@ref).
 
-**NOTE: This only works if `tex2svg` is installed.**
-**It can be installed using the following command
-    (you may have to prefix this command with `sudo` depending on your installation):**
+**NOTES:**
+- **This only works if `tex2svg` is installed.**
+    It can be installed using the following command (you may have to prefix this command with `sudo` depending on your installation):
 
-> `npm install -g mathjax-node-cli`
+        npm install -g mathjax-node-cli
+
+- **The `latex` method must be called from within a [`Action`](@ref).**
 
 # Arguments
 - `text::LaTeXString`: a LaTeX string to render.
@@ -566,11 +568,21 @@ Available actions:
 using Javis
 using LaTeXStrings
 
-my_drawing = Drawing(400, 200, "test.png")
-background("white")
-sethue("black")
-latex(L"\\sum \\phi", 100)
-finish()
+function ground(args...)
+    background("white")
+    sethue("black")
+end
+
+function draw_latex(video, action, frame)
+    latex(
+	L"\\sqrt{5}",
+        50,
+    )
+end
+
+demo = Video(500, 500)
+javis(demo, [BackgroundAction(1:2, ground), Action(draw_latex)], 
+      pathname = "latex.gif")
 ```
 
 """

--- a/src/Javis.jl
+++ b/src/Javis.jl
@@ -541,7 +541,7 @@ latex(text::LaTeXString, action::Symbol) = latex(text, 10, action)
     latex(text::LaTeXString, font_size::Real, action::Symbol)
 
 Add the latex string `text` to the top left corner of the LaTeX path.
-Can be added to `Luxor.jl` graphics such as [`Video`](@ref) or [`Drawing`](@ref).
+Can be added to `Luxor.jl` graphics via [`Video`](@ref).
 
 **NOTES:**
 - **This only works if `tex2svg` is installed.**
@@ -549,14 +549,14 @@ Can be added to `Luxor.jl` graphics such as [`Video`](@ref) or [`Drawing`](@ref)
 
         npm install -g mathjax-node-cli
 
-- **The `latex` method must be called from within a [`Action`](@ref).**
+- **The `latex` method must be called from within an [`Action`](@ref).**
 
 # Arguments
 - `text::LaTeXString`: a LaTeX string to render.
 - `font_size::Real`: font size of LaTeX string. Default `10`.
 - `action::Symbol`: graphics actions defined by `Luxor.jl`. Default `:stroke`.
 Available actions:
-  - `:stroke` -  Draws the latex string on the canvas. For more info check `Luxor.strokepath`
+  - `:stroke` - Draws the latex string on the canvas. For more info check `Luxor.strokepath`
   - `:path` - Creates the path of the latex string but does not render it to the canvas.
 
 # Throws
@@ -576,7 +576,7 @@ end
 function draw_latex(video, action, frame)
     latex(
 	L"\\sqrt{5}",
-        50,
+        50, # Adjusts the font size of the rendered LaTeX
     )
 end
 


### PR DESCRIPTION
This should fix the docstring of `latex` from issue #99 