### PR TITLE
Define SubAction on all frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Javis.jl - Changelog
 
 ## Unreleased
+- Ability to not define frames in `SubAction` -> all frames of the `Action` will be used
 - Ability to scale an object with `Scaling`. Works similar to `Translation` and `Rotation` 
 - Added JuliaFormatter GitHub Action
 

--- a/src/Javis.jl
+++ b/src/Javis.jl
@@ -145,8 +145,11 @@ mutable struct SubAction <: AbstractAction
     internal_transitions::Vector{InternalTransition}
 end
 
+SubAction(transitions::Transition...) = SubAction(:same, transitions...)
+SubAction(func::Function) = SubAction(:same, func)
+
 """
-    SubAction(frames::UnitRange, func::Function)
+    SubAction(frames, func::Function)
 
 A `SubAction` can be defined with frames and a function
 inside the `subactions` kwarg of an [`Action`](@ref).
@@ -1017,7 +1020,7 @@ function javis(
     compute_frames!(actions)
 
     for action in actions
-        compute_frames!(action.subactions)
+        compute_frames!(action.subactions; last_frames = get_frames(action))
     end
 
     # get all frames

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,13 +1,15 @@
 """
-    compute_frames!(actions::Vector{AA}) where AA <: AbstractAction
+    compute_frames!(actions::Vector{AA}; last_frames=nothing) where AA <: AbstractAction
 
 Set action.frames.frames to the computed frames for each action in actions.
 """
-function compute_frames!(actions::Vector{AA}) where {AA<:AbstractAction}
-    last_frames = nothing
+function compute_frames!(
+    actions::Vector{AA};
+    last_frames = nothing,
+) where {AA<:AbstractAction}
     for action in actions
         if last_frames === nothing && get_frames(action) === nothing
-            throw(ArgumentError("Frames need to be defined explicitly in the inital
+            throw(ArgumentError("Frames need to be defined explicitly in the initial
             AbstractAction like Action/BackgroundAction or SubAction."))
         end
         if get_frames(action) === nothing

--- a/test/unit.jl
+++ b/test/unit.jl
@@ -168,6 +168,16 @@
 
         actions = [
             BackgroundAction(1:50, (args...) -> 1),
+            Action(:atom, (args...) -> 1, subactions = [SubAction((args...) -> 1)]),
+        ]
+        demo = Video(500, 500)
+        javis(demo, actions; pathname = "")
+        @test Javis.get_frames(actions[1]) == 1:50
+        @test Javis.get_frames(actions[2]) == 1:50
+        @test Javis.get_frames(actions[2].subactions[1]) == 1:50
+
+        actions = [
+            BackgroundAction(1:50, (args...) -> 1),
             Action(
                 Rel(-19:0),
                 :atom,

--- a/test/unit.jl
+++ b/test/unit.jl
@@ -153,4 +153,36 @@
             ],
         )
     end
+
+    @testset "Frame computation" begin
+
+        actions = [
+            BackgroundAction(1:50, (args...) -> 1),
+            Action(:atom, (args...) -> 1, subactions = [SubAction(Scaling(1, 2))]),
+        ]
+        demo = Video(500, 500)
+        javis(demo, actions; pathname = "")
+        @test Javis.get_frames(actions[1]) == 1:50
+        @test Javis.get_frames(actions[2]) == 1:50
+        @test Javis.get_frames(actions[2].subactions[1]) == 1:50
+
+        actions = [
+            BackgroundAction(1:50, (args...) -> 1),
+            Action(
+                Rel(-19:0),
+                :atom,
+                (args...) -> 1,
+                subactions = [
+                    SubAction(1:10, Scaling(1, 2)),
+                    SubAction(Rel(10), Scaling(1, 2)),
+                ],
+            ),
+        ]
+        demo = Video(500, 500)
+        javis(demo, actions; pathname = "")
+        @test Javis.get_frames(actions[1]) == 1:50
+        @test Javis.get_frames(actions[2]) == 31:50
+        @test Javis.get_frames(actions[2].subactions[1]) == 1:10
+        @test Javis.get_frames(actions[2].subactions[2]) == 11:20
+    end
 end


### PR DESCRIPTION
## PR Checklist

If you are contributing to `Javis.jl`, please make sure you are able to check off each item on this list:

- [x] Did I update `CHANGELOG.md` with whatever changes/features I added with this PR?
- [X] Did I update the `TODO.md` (if applicable)?
  - wasn't in Todo
- [X] Did I make sure to only change the part of the file where I introduced a new change/feature?
- [x] Did I cover all corner cases to be close to 100% test coverage (if applicable)?
- [X] Did I properly add Javis dependencies to the `Project.toml` + set an upper bound of the dependency (if applicable)?
- [X] Did I properly add test dependencies to the `test` directory (if applicable)?
- [ ] Did I check relevant tutorials that may be affected by changes in this PR?
- [X] Did I clearly articulate why this PR was made the way it was and how it was made?

**Link to relevant issue(s)**
Closes #146 


**How did you address these issues with this PR? What methods did you use?**
With this PR it's possible to not define frames for a SubAction -> all frames of the action are used.
Added two constructors for this and changed the input of `last_frames` for SubAction.



