### PR TITLE
removed possibility to set the fontsize inside the latex function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Use [VideoIO](https://github.com/JuliaIO/VideoIO.jl) for faster rendering without temporary images
 - Ability to morph with `fill` or `stroke` and using `SubAction` to specify changes in color
 
+### Removed
+- `latex` no longer takes the `fontsize` as an argument [PR #180](https://github.com/Wikunia/Javis.jl/pull/180)
+
 ## 0.1.3 (11th of September 2020)
 - First `SubAction` for an `Action` no longer requires explicit frame range and will default to the frames of the `Action`
 - Ability to scale an object with `Scaling`. Works similar to `Translation` and `Rotation` 

--- a/src/Javis.jl
+++ b/src/Javis.jl
@@ -813,6 +813,7 @@ function ground(args...)
 end
 
 function draw_latex(video, action, frame)
+    fontsize(50)
     x = 100
     y = 120
     latex(L"\\sqrt{5}", x, y)

--- a/src/Javis.jl
+++ b/src/Javis.jl
@@ -774,10 +774,6 @@ include("javis_viewer.jl")
 latex(text::LaTeXString) = latex(text, O)
 latex(text::LaTeXString, pos::Point) = latex(text, pos, :stroke)
 latex(text::LaTeXString, x, y) = latex(text, Point(x, y), :stroke)
-@deprecate latex(text::LaTeXString, fsize::Real) begin
-    fontsize(fsize)
-    latex(text)
-end
 
 """
     latex(text::LaTeXString, pos::Point, action::Symbol)

--- a/test/svg.jl
+++ b/test/svg.jl
@@ -55,32 +55,3 @@ end
     @test_reference "refs/ologn_circ.png" load("images/0000000001.png")
     rm("images/0000000001.png")
 end
-
-@testset "latex pos in function DEPRECATED" begin
-    function latex_ground(args...)
-        background("white")
-        sethue("black")
-        fontsize(30)
-    end
-
-    function foreground(latex_string)
-        translate(50, 40)
-        fsize = get_fontsize()
-        latex(latex_string, fsize) # is automatically changed to fontsize(30); latex(latex_string)
-        translate(-50, -40)
-        circle(O, 20, :fill) # should be in the center and not affected by latex
-    end
-
-    video = Video(400, 200)
-    javis(
-        video,
-        [
-            BackgroundAction(1:1, latex_ground),
-            Action((args...) -> foreground(L"\mathcal{O}(\log{n})")),
-        ],
-        tempdirectory = "images",
-        pathname = "",
-    )
-    @test_reference "refs/ologn_circ.png" load("images/0000000001.png")
-    rm("images/0000000001.png")
-end


### PR DESCRIPTION
## PR Checklist

If you are contributing to `Javis.jl`, please make sure you are able to check off each item on this list:

- [x] Did I update `CHANGELOG.md` with whatever changes/features I added with this PR?
- [x] Did I make sure to only change the part of the file where I introduced a new change/feature?
- [x] Did I cover all corner cases to be close to 100% test coverage (if applicable)?
- [x] Did I properly add Javis dependencies to the `Project.toml` + set an upper bound of the dependency (if applicable)?
- [x] Did I properly add test dependencies to the `test` directory (if applicable)?
- [x] Did I check relevant tutorials that may be affected by changes in this PR?
- [x] Did I clearly articulate why this PR was made the way it was and how it was made?

**How did you address these issues with this PR? What methods did you use?**

This removes the current deprecation warning for `latex(latexstring, 25)` where 25 is the fontsize. We don't support this anymore and we had the deprecation warning for v0.1.3 -> v0.1.5 so with v0.2 we don't want to keep this.
If you find this PR and want to know how to set the font size:

```
fontsize(20)
latex(latexstring)
```

is the way to go.


