### PR TITLE
[Bugfix] return 1.0 in interpolation for single frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   - Currently must be invoked after `javis` function call
   - Can be called via `Javis.get_javis_frame` as it is not exported yet
 - An object described by an action can follow a path (a vector of points). See `follow_path`
+- Bugfix in interpolation: Interpolation of a single frame like `1:1` returns `1.0` now instead of `NaN`.
 
   
 ## 0.1.5 (14th of September 2020)

--- a/src/util.jl
+++ b/src/util.jl
@@ -35,6 +35,7 @@ end
 Return a value between 0 and 1 which represents the relative `frame` inside `frames`.
 """
 function get_interpolation(frames::UnitRange, frame)
+    frame == last(frames) && return 1.0
     t = (frame - first(frames)) / (length(frames) - 1)
     # makes sense to only allow 0 ≤ t ≤ 1
     t = min(1.0, t)

--- a/test/unit.jl
+++ b/test/unit.jl
@@ -272,6 +272,16 @@
         @test action.internal_transitions[1].center == Point(2.0, 5.0)
     end
 
+    @testset "action with a single frame" begin
+        video = Video(500, 500)
+        # dummy action doesn't need a real function
+        action = Action(1:1, () -> 1, Translation(Point(10, 10)))
+        # needs internal translation as well
+        push!(action.internal_transitions, Javis.InternalTranslation(O))
+        Javis.compute_transformation!(action, video, 1)
+        @test action.internal_transitions[1].by == Point(10, 10)
+    end
+
     @testset "Frames errors" begin
         # throws because a Video object was not previously defined
         empty!(Javis.CURRENT_VIDEO)


### PR DESCRIPTION
## PR Checklist

If you are contributing to `Javis.jl`, please make sure you are able to check off each item on this list:

- [x] Did I update `CHANGELOG.md` with whatever changes/features I added with this PR?
- [x] Did I make sure to only change the part of the file where I introduced a new change/feature?
- [x] Did I cover all corner cases to be close to 100% test coverage (if applicable)?
- [x] Did I properly add Javis dependencies to the `Project.toml` + set an upper bound of the dependency (if applicable)?
- [x] Did I properly add test dependencies to the `test` directory (if applicable)?
- [x] Did I check relevant tutorials that may be affected by changes in this PR?
- [x] Did I clearly articulate why this PR was made the way it was and how it was made?

**Link to relevant issue(s)**
Closes #187

**How did you address these issues with this PR? What methods did you use?**
If `get_interpolation` is called with the last frame it returns 1.0 without any computation



