### PR TITLE
convert frame only once

### DIFF
--- a/src/Javis.jl
+++ b/src/Javis.jl
@@ -1249,7 +1249,7 @@ function javis(
 
     filecounter = 1
     @showprogress 1 "Rendering frames..." for frame in frames
-        frame_image = get_javis_frame(video, actions, frame, RGB)
+        frame_image = convert.(RGB, get_javis_frame(video, actions, frame))
         if !isempty(tempdirectory)
             Images.save("$(tempdirectory)/$(lpad(filecounter, 10, "0")).png", frame_image)
         end
@@ -1286,7 +1286,7 @@ function javis(
 end
 
 """
-    get_javis_frame(video, actions, frame, img_type=ARGB32)
+    get_javis_frame(video, actions, frame)
 
 Get a frame from an animation given a video object, its actions, and frame.
 
@@ -1294,12 +1294,11 @@ Get a frame from an animation given a video object, its actions, and frame.
 - `video::Video`: The video which defines the dimensions of the output
 - `actions::Vector{Action}`: All actions that are performed
 - `frame::Int`: Specific frame to be returned
-- `img_type`: ARGB32 by default
 
 # Returns
-- `Array{img_type, 2}` - request frame as a matrix
+- `Array{ARGB32, 2}` - request frame as a matrix
 """
-function get_javis_frame(video, actions, frame, img_type = ARGB32)
+function get_javis_frame(video, actions, frame)
     background_settings = ActionSetting()
     Drawing(video.width, video.height, :image)
     origin()
@@ -1327,7 +1326,7 @@ function get_javis_frame(video, actions, frame, img_type = ARGB32)
         # if action is in global layer this changes the background settings
         update_background_settings!(background_settings, action)
     end
-    img = convert.(img_type, image_as_matrix())
+    img = image_as_matrix()
     finish()
     return img
 end

--- a/src/Javis.jl
+++ b/src/Javis.jl
@@ -1249,7 +1249,7 @@ function javis(
 
     filecounter = 1
     @showprogress 1 "Rendering frames..." for frame in frames
-        frame_image = convert.(RGB, get_javis_frame(video, actions, frame))
+        frame_image = get_javis_frame(video, actions, frame, RGB)
         if !isempty(tempdirectory)
             Images.save("$(tempdirectory)/$(lpad(filecounter, 10, "0")).png", frame_image)
         end
@@ -1286,7 +1286,7 @@ function javis(
 end
 
 """
-    get_javis_frame(video, actions, frame)
+    get_javis_frame(video, actions, frame, img_type=ARGB32)
 
 Get a frame from an animation given a video object, its actions, and frame.
 
@@ -1294,11 +1294,12 @@ Get a frame from an animation given a video object, its actions, and frame.
 - `video::Video`: The video which defines the dimensions of the output
 - `actions::Vector{Action}`: All actions that are performed
 - `frame::Int`: Specific frame to be returned
+- `img_type`: ARGB32 by default
 
 # Returns
-- `Array{ARGB32, 2}` - request frame as a matrix
+- `Array{img_type, 2}` - request frame as a matrix
 """
-function get_javis_frame(video, actions, frame)
+function get_javis_frame(video, actions, frame, img_type = ARGB32)
     background_settings = ActionSetting()
     Drawing(video.width, video.height, :image)
     origin()
@@ -1312,7 +1313,7 @@ function get_javis_frame(video, actions, frame)
         if frame in get_frames(action)
             # check if the action should be part of the global layer (i.e BackgroundAction)
             # or in its own layer (default)
-            in_global_layer = get(action.opts, :in_global_layer, false)
+            in_global_layer = get(action.opts, :in_global_layer, false)::Bool
             if !in_global_layer
                 @layer begin
                     perform_action(action, video, frame, origin_matrix)
@@ -1326,7 +1327,7 @@ function get_javis_frame(video, actions, frame)
         # if action is in global layer this changes the background settings
         update_background_settings!(background_settings, action)
     end
-    img = convert.(ARGB32, image_as_matrix())
+    img = convert.(img_type, image_as_matrix())
     finish()
     return img
 end


### PR DESCRIPTION
## PR Checklist

If you are contributing to `Javis.jl`, please make sure you are able to check off each item on this list:

- [x] Did I update `CHANGELOG.md` with whatever changes/features I added with this PR?
- [x] Did I make sure to only change the part of the file where I introduced a new change/feature?
- [x] Did I cover all corner cases to be close to 100% test coverage (if applicable)?
- [x] Did I properly add Javis dependencies to the `Project.toml` + set an upper bound of the dependency (if applicable)?
- [x] Did I properly add test dependencies to the `test` directory (if applicable)?
- [x] Did I check relevant tutorials that may be affected by changes in this PR?
- [x] Did I clearly articulate why this PR was made the way it was and how it was made?

**Link to relevant issue(s)**
None


**How did you address these issues with this PR? What methods did you use?**
Currently the `get_javis_frame` function would convert the frame to `ARGB32` and inside `javis` it would be converted to `RGB`. This is stupid :smile:  -> convert it directly to the image type we need.


