### PR TITLE
Warning if action is defined out of object frames

### DIFF
--- a/src/Javis.jl
+++ b/src/Javis.jl
@@ -139,8 +139,8 @@ Shows a warning if some frames don't have a background.
 function preprocess_frames!(objects::Vector{<:AbstractObject})
     compute_frames!(objects)
 
-    for object in objects
-        compute_frames!(object.actions; parent = object)
+    for (i, object) in enumerate(objects)
+        compute_frames!(object.actions; parent = object, parent_counter=i)
     end
 
     # get all frames

--- a/src/Javis.jl
+++ b/src/Javis.jl
@@ -140,7 +140,7 @@ function preprocess_frames!(objects::Vector{<:AbstractObject})
     compute_frames!(objects)
 
     for (i, object) in enumerate(objects)
-        compute_frames!(object.actions; parent = object, parent_counter=i)
+        compute_frames!(object.actions; parent = object, parent_counter = i)
     end
 
     # get all frames

--- a/src/util.jl
+++ b/src/util.jl
@@ -12,7 +12,7 @@ function compute_frames!(
     available_subframes = typemin(Int):typemax(Int)
     if parent !== nothing
         last_frames = get_frames(parent)
-        available_subframes = get_frames(parent)
+        available_subframes = 1:length(get_frames(parent))
     else
         last_frames = nothing
     end
@@ -30,7 +30,7 @@ function compute_frames!(
         if !(get_frames(elem) ⊆ available_subframes)
             @warn("An Action defines frames outside the range of the parental object.
             In particular Action #$counter for Object #$parent_counter is defined for frames
-            $(get_frames(elem)) but the object exists only for $(available_subframes).
+            $(get_frames(elem)) but the object exists only for $(length(available_subframes)) frames.
             (Info: the Background is counted as Object #1)")
         end
         is_first = false

--- a/src/util.jl
+++ b/src/util.jl
@@ -28,10 +28,10 @@ function compute_frames!(
         end
         last_frames = get_frames(elem)
         if !(get_frames(elem) ⊆ available_subframes)
-            @warn("An Action defines frames outside the range of the parental object.
-            In particular Action #$counter for Object #$parent_counter is defined for frames
-            $(get_frames(elem)) but the object exists only for $(length(available_subframes)) frames.
-            (Info: the Background is counted as Object #1)")
+            @warn("Action defined outside the frame range of the parent object.
+            Action #$counter for Object #$parent_counter is defined for frames
+            $(get_frames(elem)) but Object #$parent_counter exists only for $(available_subframes).
+            (Info: Background is counted as Object #1)")
         end
         is_first = false
         counter += 1

--- a/src/util.jl
+++ b/src/util.jl
@@ -7,13 +7,17 @@ Set elem.frames.frames to the computed frames for each elem in elements.
 function compute_frames!(
     elements::Vector{UA};
     parent = nothing,
+    parent_counter = 0,
 ) where {UA<:Union{AbstractObject,AbstractAction}}
+    available_subframes = typemin(Int):typemax(Int)
     if parent !== nothing
         last_frames = get_frames(parent)
+        available_subframes = get_frames(parent)
     else
         last_frames = nothing
     end
     is_first = true
+    counter = 1
     for elem in elements
         if last_frames === nothing && get_frames(elem) === nothing
             throw(ArgumentError("Frames need to be defined explicitly in the initial
@@ -23,7 +27,14 @@ function compute_frames!(
             set_frames!(parent, elem, last_frames; is_first = is_first)
         end
         last_frames = get_frames(elem)
+        if !(get_frames(elem) ⊆ available_subframes)
+            @warn("An Action defines frames outside the range of the parental object.
+            In particular Action #$counter for Object #$parent_counter is defined for frames
+            $(get_frames(elem)) but the object exists only for $(available_subframes).
+            (Info: the Background is counted as Object #1)")
+        end
         is_first = false
+        counter += 1
     end
 end
 

--- a/test/unit.jl
+++ b/test/unit.jl
@@ -281,4 +281,11 @@
         Object(1:11, (args...) -> 2)
         @test_logs (:warn,) render(video; pathname = "")
     end
+
+    @testset "Test warning if action outside frame range" begin
+        video = Video(100, 100)
+        Background(1:20, (args...) -> 1)
+        act!(Object(1:11, (args...) -> 2), Action(1:20, anim_translate(0, 10)))
+        @test_logs (:warn,) render(video; pathname = "")
+    end
 end


### PR DESCRIPTION
## PR Checklist

If you are contributing to `Javis.jl`, please make sure you are able to check off each item on this list:

- [ ] Did I update `CHANGELOG.md` with whatever changes/features I added with this PR?
- [x] Did I make sure to only change the part of the file where I introduced a new change/feature?
- [x] Did I cover all corner cases to be close to 100% test coverage (if applicable)?
- [x] Did I properly add Javis dependencies to the `Project.toml` + set an upper bound of the dependency (if applicable)?
- [x] Did I properly add test dependencies to the `test` directory (if applicable)?
- [x] Did I check relevant tutorials that may be affected by changes in this PR?
- [x] Did I clearly articulate why this PR was made the way it was and how it was made?

**Link to relevant issue(s)**
#249 point 2


**How did you address these issues with this PR? What methods did you use?**
I check the length of the object that exists and compare whether the action is defined for a range outside of that frames.
The warning message tries to give the best clue possible by giving the number of the action and object and the frame range that it could be in vs the one it is in.


