### PR TITLE
kwarg: ffmpeg_loglevel

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,13 +26,14 @@ A clear and concise description of what the bug is.
 
 3. Javis version (i.e output of `] status Javis` in the REPL)
 
-4. Minimum working code example that led to bug:
+5. Minimum working code example that led to bug:
 
 **Expected Behavior and Actual Behavior**
 
 A clear and concise description of what you expected to happen followed up with an explanation of what actually happened.
 
 **Stacktrace (If Applicable)**
+If the stacktrace includes some ffmpeg error please use `ffmpeg_loglevel = "info"` inside your `render` command.
 
 **Screenshots**
 If applicable, add your gif or drawing to help explain your problem.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,14 +26,14 @@ A clear and concise description of what the bug is.
 
 3. Javis version (i.e output of `] status Javis` in the REPL)
 
-5. Minimum working code example that led to bug:
+4. Minimum working code example that led to bug:
 
 **Expected Behavior and Actual Behavior**
 
 A clear and concise description of what you expected to happen followed up with an explanation of what actually happened.
 
 **Stacktrace (If Applicable)**
-If the stacktrace includes some ffmpeg error please use `ffmpeg_loglevel = "info"` inside your `render` command.
+If the stacktrace includes some ffmpeg error please set the kwarg `ffmpeg_loglevel` to `"info"` i.e `render(your_video, "your_animation.gif", ffmpeg_loglevel = "info")`
 
 **Screenshots**
 If applicable, add your gif or drawing to help explain your problem.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Javis.jl - Changelog
 
-## v0.3.2 (22th of November)
+## v0.3.2 (24th of November)
 - added `ffmpeg_loglevel` option for debugging purposes
 
 ## v0.3.1 (18th of November 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Javis.jl - Changelog
 
+## v0.3.2 (22th of November)
+- added `ffmpeg_loglevel` option for debugging purposes
+
 ## v0.3.1 (18th of November 2020)
 - removed `ColorTypes` as a dependency
 - docstring fixes for `morph_to`

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Javis"
 uuid = "78b212ba-a7f9-42d4-b726-60726080707e"
 authors = ["Ole Kröger <o.kroeger@opensourc.es>", "Jacob Zelko <jacobszelko@gmail.com>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 Animations = "27a7e980-b3e6-11e9-2bcd-0b925532e340"

--- a/src/Javis.jl
+++ b/src/Javis.jl
@@ -163,7 +163,8 @@ end
         framerate=30,
         pathname="javis_GIBBERISH.gif",
         tempdirectory="",
-        liveview=false
+        liveview=false,
+        ffmpeg_loglevel="panic"
     )
 
 Renders all previously defined [`Object`](@ref) drawings to the user-defined `Video` as a gif or mp4.
@@ -178,6 +179,9 @@ Renders all previously defined [`Object`](@ref) drawings to the user-defined `Vi
 - `tempdirectory::String`: The folder where each frame is stored
     Defaults to a temporary directory when not set
 - `liveview::Bool`: Causes a live image viewer to appear to assist with animation development
+- `ffmpeg_loglevel::String`:
+    - Can be used if there are errors with ffmpeg. Defaults to panic:
+    All other options are described here: https://ffmpeg.org/ffmpeg.html
 """
 function render(
     video::Video;
@@ -185,6 +189,7 @@ function render(
     pathname = "javis_$(randstring(7)).gif",
     liveview = false,
     tempdirectory = "",
+    ffmpeg_loglevel="panic"
 )
     objects = video.objects
     frames = preprocess_frames!(objects)
@@ -231,10 +236,10 @@ function render(
     isempty(pathname) && return
     if ext == ".gif"
         # generate a colorpalette first so ffmpeg does not have to guess it
-        ffmpeg_exe(`-loglevel panic -i $(tempdirectory)/%10d.png -vf
+        ffmpeg_exe(`-loglevel $(ffmpeg_loglevel) -i $(tempdirectory)/%10d.png -vf
                     "palettegen=stats_mode=diff" -y "$(tempdirectory)/palette.bmp"`)
         # then apply the palette to get better results
-        ffmpeg_exe(`-loglevel panic -framerate $framerate -i $(tempdirectory)/%10d.png -i
+        ffmpeg_exe(`-loglevel $(ffmpeg_loglevel) -framerate $framerate -i $(tempdirectory)/%10d.png -i
                     "$(tempdirectory)/palette.bmp" -lavfi
                     "paletteuse=dither=sierra2_4a" -y $pathname`)
     elseif ext == ".mp4"

--- a/src/Javis.jl
+++ b/src/Javis.jl
@@ -189,7 +189,7 @@ function render(
     pathname = "javis_$(randstring(7)).gif",
     liveview = false,
     tempdirectory = "",
-    ffmpeg_loglevel="panic"
+    ffmpeg_loglevel = "panic",
 )
     objects = video.objects
     frames = preprocess_frames!(objects)


### PR DESCRIPTION
## PR Checklist

If you are contributing to `Javis.jl`, please make sure you are able to check off each item on this list:

- [x] Did I update `CHANGELOG.md` with whatever changes/features I added with this PR?
- [x] Did I make sure to only change the part of the file where I introduced a new change/feature?
- [x] Did I cover all corner cases to be close to 100% test coverage (if applicable)?
- [x] Did I properly add Javis dependencies to the `Project.toml` + set an upper bound of the dependency (if applicable)?
- [x] Did I properly add test dependencies to the `test` directory (if applicable)?
- [x] Did I check relevant tutorials that may be affected by changes in this PR?
- [x] Did I clearly articulate why this PR was made the way it was and how it was made?

**How did you address these issues with this PR? What methods did you use?**
I've added a kwarg `ffmpeg_loglevel` which defaults to `"panic"` as before but can be changed to `"info"` or some others.
Additionally I've added it to the issue template such that if ffmpeg fails we get more information.
The changelog and Project.toml are updated to release v0.3.2 when this is merged.

