### PR TITLE
set always_use_return to false in formatter

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -2,3 +2,4 @@ annotate_untyped_fields_with_any = false
 always_for_in = true
 whitespace_in_kwargs = true
 whitespace_ops_in_indices = true
+always_use_return = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Javis.jl - Changelog
 
+## v0.4.0
+- added ImageIO and ImageMagick as dependencies
+
 ## v0.3.4 (23rd of December 2020)
 - Bugfix: `get_latex_svg` assumed a `LaTeXString` always includes `$$`
 - changed color palette for gif rendering

--- a/examples/follow_path.jl
+++ b/examples/follow_path.jl
@@ -2,12 +2,12 @@ using Javis, Animations
 
 function ground(args...)
     background("white")
-    return sethue("black")
+    sethue("black")
 end
 
 function circle_with_color(pos, radius, color)
     sethue(color)
-    return circle(pos, radius, :fill)
+    circle(pos, radius, :fill)
 end
 
 # the safest option is to declare the Video first all the time
@@ -39,8 +39,8 @@ Background(1:220, ground)
 
 # let the points appear one by one
 objects = [
-    Object(frame_start:200, (args...) -> circle(O, 10, :fill), points[i])
-    for (frame_start, i) in zip(1:2:(2 * npoints), 1:npoints)
+    Object(frame_start:200, (args...) -> circle(O, 10, :fill), points[i]) for
+    (frame_start, i) in zip(1:2:(2 * npoints), 1:npoints)
 ]
 
 # easiest to move canvas to draw at origin

--- a/examples/fourier.jl
+++ b/examples/fourier.jl
@@ -12,7 +12,7 @@ using TravelingSalesmanHeuristics
 
 function ground(args...)
     background("black")
-    return sethue("white")
+    sethue("white")
 end
 
 function circ(; r = 10, vec = O, action = :stroke, color = "white")
@@ -43,7 +43,7 @@ function draw_line(
     sethue(color)
     setdash(edge)
     setline(linewidth)
-    return line(p1, p2, action)
+    line(p1, p2, action)
 end
 
 function draw_path!(path, pos, color)
@@ -89,8 +89,8 @@ function get_points(npoints, options)
         portion = len / total_distance
         nlocalpoints = floor(Int, portion * npoints)
         new_points = [
-            Javis.get_polypoint_at(shape, i / (nlocalpoints - 1))
-            for i in 0:(nlocalpoints - 1)
+            Javis.get_polypoint_at(shape, i / (nlocalpoints - 1)) for
+            i in 0:(nlocalpoints - 1)
         ]
         append!(points, new_points)
         new_i = start_i + length(new_points) - 1

--- a/examples/projection.jl
+++ b/examples/projection.jl
@@ -4,7 +4,7 @@ nframes = 200
 
 function ground(args...)
     background("white") # canvas background
-    return sethue("black") # pen color
+    sethue("black") # pen color
 end
 
 myvideo = Video(300, 300)
@@ -13,7 +13,7 @@ Background(1:200, ground)
 function draw_line(p1 = O, p2 = O, color = "black", action = :stroke, edge = "solid")
     sethue(color)
     setdash(edge)
-    return line(p1, p2, action)
+    line(p1, p2, action)
 end
 
 # Draw the coordinate lines with solid in the positive side and dashed in the negative one

--- a/src/Javis.jl
+++ b/src/Javis.jl
@@ -146,7 +146,9 @@ function preprocess_frames!(objects::Vector{<:AbstractObject})
     end
     frames = unique(frames)
     if !(frames ⊆ CURRENT_VIDEO[1].background_frames)
-        @warn("Some of the frames don't have a background. In this case: $(setdiff(frames, CURRENT_VIDEO[1].background_frames)))")
+        @warn(
+            "Some of the frames don't have a background. In this case: $(setdiff(frames, CURRENT_VIDEO[1].background_frames)))"
+        )
     end
 
     if isempty(CURRENT_OBJECT)
@@ -239,8 +241,10 @@ function render(
         ffmpeg_exe(`-loglevel $(ffmpeg_loglevel) -i $(tempdirectory)/%10d.png -vf
                     palettegen $(tempdirectory)/palette.png`)
         # then apply the palette to get better results
-        ffmpeg_exe(`-loglevel $(ffmpeg_loglevel) -framerate $framerate -i $(tempdirectory)/%10d.png -i
-                      $(tempdirectory)/palette.png -lavfi paletteuse -y $pathname`)
+        ffmpeg_exe(
+            `-loglevel $(ffmpeg_loglevel) -framerate $framerate -i $(tempdirectory)/%10d.png -i
+               $(tempdirectory)/palette.png -lavfi paletteuse -y $pathname`,
+        )
     elseif ext == ".mp4"
         finishencode!(video_encoder, video_io)
         close(video_io)

--- a/src/Shape.jl
+++ b/src/Shape.jl
@@ -67,11 +67,15 @@ function get_angles(p)
             pB = p[1]
             pC = p[2]
         end
-        ang = rad2deg(acos(clamp(
-            dotproduct(u, v) / (sqrt(u.x^2 + u.y^2) * sqrt(v.x^2 + v.y^2)),
-            -1,
-            1,
-        )))
+        ang = rad2deg(
+            acos(
+                clamp(
+                    dotproduct(u, v) / (sqrt(u.x^2 + u.y^2) * sqrt(v.x^2 + v.y^2)),
+                    -1,
+                    1,
+                ),
+            ),
+        )
         if ang < 179.8
             push!(simplified, pB)
         end
@@ -210,7 +214,9 @@ end
 
 function print_basic(s::Shape)
     println("Shape: #Points: $(length(s.points))")
-    println("Angles: #Acute: $(s.num_acute_angles) #Obtuse: $(s.num_obtuse_angles) #Right: $(s.num_right_angles)")
+    println(
+        "Angles: #Acute: $(s.num_acute_angles) #Obtuse: $(s.num_obtuse_angles) #Right: $(s.num_right_angles)",
+    )
     println("#Holes: $(length(s.subpaths))")
 end
 

--- a/src/structs/Frames.jl
+++ b/src/structs/Frames.jl
@@ -52,7 +52,11 @@ function get_frames(parent, elem, frames::Symbol, last_frames::UnitRange; is_fir
         end
         return last_frames
     else
-        throw(ArgumentError("Currently the only symbol supported for defining frames is `:same`"))
+        throw(
+            ArgumentError(
+                "Currently the only symbol supported for defining frames is `:same`",
+            ),
+        )
     end
 end
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -28,10 +28,12 @@ function compute_frames!(
         end
         last_frames = get_frames(elem)
         if !(get_frames(elem) ⊆ available_subframes)
-            @warn("Action defined outside the frame range of the parent object.
-            Action #$counter for Object #$parent_counter is defined for frames
-            $(get_frames(elem)) but Object #$parent_counter exists only for $(available_subframes).
-            (Info: Background is counted as Object #1)")
+            @warn(
+                "Action defined outside the frame range of the parent object.
+          Action #$counter for Object #$parent_counter is defined for frames
+          $(get_frames(elem)) but Object #$parent_counter exists only for $(available_subframes).
+          (Info: Background is counted as Object #1)"
+            )
         end
         is_first = false
         counter += 1

--- a/test/svg.jl
+++ b/test/svg.jl
@@ -54,8 +54,9 @@ end
     video = Video(400, 200)
     Background(1:1, latex_ground)
     Object(
-        (args...) ->
-            latex(L"$\begin{equation}\left[\begin{array}{ccc}1 & 2 & 3 \\4 & 5 & 6 \\7 & 8 & 9 \\\end{array}\right]\end{equation}$"),
+        (args...) -> latex(
+            L"$\begin{equation}\left[\begin{array}{ccc}1 & 2 & 3 \\4 & 5 & 6 \\7 & 8 & 9 \\\end{array}\right]\end{equation}$",
+        ),
     )
     render(video; tempdirectory = "images", pathname = "")
     @test_reference "refs/latex_3x3_matrix.png" load("images/0000000001.png")


### PR DESCRIPTION
## PR Checklist

If you are contributing to `Javis.jl`, please make sure you are able to check off each item on this list:

- [x] Did I update `CHANGELOG.md` with whatever changes/features I added with this PR?
- [x] Did I make sure to only change the part of the file where I introduced a new change/feature?
- [x] Did I cover all corner cases to be close to 100% test coverage (if applicable)?
- [x] Did I properly add Javis dependencies to the `Project.toml` + set an upper bound of the dependency (if applicable)?
- [x] Did I properly add test dependencies to the `test` directory (if applicable)?
- [x] Did I check relevant tutorials that may be affected by changes in this PR?
- [x] Did I clearly articulate why this PR was made the way it was and how it was made?

**How did you address these issues with this PR? What methods did you use?**
I'm not a fan of `always_use_return` therefore I disabled it. :wink: I think it makes sense to explicitly use `return` when one wishes to use the value afterwards which isn't the case for things like `sethue`.


