### PR TITLE
Fix minor typo in tutorials

### DIFF
--- a/docs/src/tutorials/tutorial_2.md
+++ b/docs/src/tutorials/tutorial_2.md
@@ -146,7 +146,7 @@ The following code places a vertical and horizontal axis as well as an inscribed
 
 ```julia
 ...
-inside_circle = Object((args...) -> circ(O, "black", :stroke, 170))
+inside_circle = Object((args...) -> circ(O, "black", :stroke, 140, "longdashed"))
 vert_line = Object(
     (args...) ->
         draw_line(Point(0, -170), Point(0, 170), "black", :stroke, "longdashed"),
@@ -438,7 +438,7 @@ demo = Video(500, 500)
 
 anim_background = Background(1:10, ground)
 head = Object((args...) -> circ(O, "black", :stroke, 170))
-inside_circle = Object((args...) -> circ(O, "black", :stroke, 170))
+inside_circle = Object((args...) -> circ(O, "black", :stroke, 140, "longdashed"))
 vert_line = Object(
     (args...) ->
         draw_line(Point(0, -170), Point(0, 170), "black", :stroke, "longdashed"),


### PR DESCRIPTION
## PR Checklist

If you are contributing to `Javis.jl`, please make sure you are able to check off each item on this list:

- [ ] Did I update `CHANGELOG.md` with whatever changes/features I added with this PR?
- [x] Did I make sure to only change the part of the file where I introduced a new change/feature?
- [ ] Did I cover all corner cases to be close to 100% test coverage (if applicable)?
- [ ] Did I properly add Javis dependencies to the `Project.toml` + set an upper bound of the dependency (if applicable)?
- [ ] Did I properly add test dependencies to the `test` directory (if applicable)?
- [x] Did I check relevant tutorials that may be affected by changes in this PR?
- [x] Did I clearly articulate why this PR was made the way it was and how it was made?

**Link to relevant issue(s)**
No issues linked. (Since this is a minor change I left out creating an issue for it. If required will willingly do so.)


**How did you address these issues with this PR? What methods did you use?**
There seems to be a minor typo in Tutorial-2. The inner circle has a few wrong parameters. Corrected it using the examples from the rest of the tutorial. 

Thanks for the awesome package and the wonderful tutorials!


