### PR TITLE
Fixed article in some places in docstrings

### DIFF
--- a/src/action_animations.jl
+++ b/src/action_animations.jl
@@ -247,7 +247,7 @@ end
 """
     scale()
 
-Scale a function defined inside a [`Action`](@ref) using an Animation defined
+Scale a function defined inside an [`Action`](@ref) using an Animation defined
 with Animations.jl.
 
 An example can be seen in [`rotate`](@ref).

--- a/src/structs/Action.jl
+++ b/src/structs/Action.jl
@@ -1,10 +1,10 @@
 """
     Action <: AbstractAction
 
-A Action can be used in the keyword arguments of an [`Object`](@ref) to define small
+An Action can be used in the keyword arguments of an [`Object`](@ref) to define small
 sub objects on the object function, such as [`appear`](@ref).
 
-A Action should not be created by hand but instead by using one of the constructors.
+An Action should not be created by hand but instead by using one of the constructors.
 
 # Fields
 - `frames::Frames`: the frames relative to the parent [`Object`](@ref)


### PR DESCRIPTION
Fixed articles from `a` to `an` for `Action` in `Action.jl` and `action_animation.jl`

## PR Checklist

If you are contributing to `Javis.jl`, please make sure you are able to check off each item on this list:

- [ ] Did I update `CHANGELOG.md` with whatever changes/features I added with this PR?
- [x] Did I make sure to only change the part of the file where I introduced a new change/feature?
- [ ] Did I cover all corner cases to be close to 100% test coverage (if applicable)?
- [ ] Did I properly add Javis dependencies to the `Project.toml` + set an upper bound of the dependency (if applicable)?
- [ ] Did I properly add test dependencies to the `test` directory (if applicable)?
- [x] Did I check relevant tutorials that may be affected by changes in this PR?
- [x] Did I clearly articulate why this PR was made the way it was and how it was made?



