### PR TITLE
Tutorial update to clarify that we use the letter O

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Javis.jl - Changelog
 
-## Unreleased
+## v0.5.1
 - add alignment options to latex rendering
+- clarified `O` as origin in tutorial 1
 
 ## v0.5.0 (29th of March 2021)
 - `:all` can now be used to have an Object persist for all frames of an animation

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Javis"
 uuid = "78b212ba-a7f9-42d4-b726-60726080707e"
 authors = ["Ole Kröger <o.kroeger@opensourc.es>", "Jacob Zelko <jacobszelko@gmail.com>"]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 Animations = "27a7e980-b3e6-11e9-2bcd-0b925532e340"

--- a/docs/src/tutorials/tutorial_1.md
+++ b/docs/src/tutorials/tutorial_1.md
@@ -91,7 +91,7 @@ In general you can use all `Luxor` functions inside `Javis`. `Javis` is just an 
 
 The code snippet above defines a function which will be used to animate a circle in the next section. It takes in a point and a color as keyword arguments. 
 
-> **NOTE:** You may notice in the `object` method, there is a kwarg called `p`, standing for the "point" of where to draw the object, which defaults to the character `O`.
+> **NOTE:** You may notice in the `object` method, there is a kwarg called `p`, standing for the "point" of where to draw the object, which defaults to the letter `O` for origin.
 This is a shorthand provided by `Luxor` which is the same as `Point(0, 0)`.
 If one wishes to be more explicit, one can define the function header as `function object(p=Point(0,0), color="black")`.
 

--- a/test/morphing.jl
+++ b/test/morphing.jl
@@ -65,9 +65,11 @@ end
 
     function matrix(args...; do_transpose = false, do_action = :stroke)
         fontsize(50)
-        str = L"$\begin{equation}\left[\begin{array}{ccc}\alpha & \beta & \gamma \\x^{2} & \sqrt{y} & \lambda \\1 & 2 & y \\\end{array}\right]\end{equation}$"
+        str =
+            L"$\begin{equation}\left[\begin{array}{ccc}\alpha & \beta & \gamma \\x^{2} & \sqrt{y} & \lambda \\1 & 2 & y \\\end{array}\right]\end{equation}$"
         if do_transpose
-            str = L"$\begin{equation}\left[\begin{array}{ccc}\alpha & x^{2} & 1 \\\beta & \sqrt{y} & 2 \\\gamma & \lambda & y \\\end{array}\right]\end{equation}$"
+            str =
+                L"$\begin{equation}\left[\begin{array}{ccc}\alpha & x^{2} & 1 \\\beta & \sqrt{y} & 2 \\\gamma & \lambda & y \\\end{array}\right]\end{equation}$"
         end
         latex(str, O, do_action)
     end
@@ -102,9 +104,11 @@ end
     function sequence(args...; second = false, do_action = :stroke)
         fontsize(50)
 
-        str = L"$\begin{equation}\left[\begin{array}{cc}2 & -1\\-1 & 2 \\\end{array}\right]\end{equation}$"
+        str =
+            L"$\begin{equation}\left[\begin{array}{cc}2 & -1\\-1 & 2 \\\end{array}\right]\end{equation}$"
         if second
-            str = L"$\begin{equation}\left[\begin{array}{ccc} 2 & -1 & 0 \\ -1 & 2 & -1 \\ 0 & -1 & 2 \\\end{array}\right]\end{equation}$"
+            str =
+                L"$\begin{equation}\left[\begin{array}{ccc} 2 & -1 & 0 \\ -1 & 2 & -1 \\ 0 & -1 & 2 \\\end{array}\right]\end{equation}$"
         end
         if !second
             latex(str, Point(-150, -60), do_action)


### PR DESCRIPTION
## PR Checklist

If you are contributing to `Javis.jl`, please make sure you are able to check off each item on this list:

- [x] Did I update `CHANGELOG.md` with whatever changes/features I added with this PR?
- [x] Did I make sure to only change the part of the file where I introduced a new change/feature?
- [x] Did I cover all corner cases to be close to 100% test coverage (if applicable)?
- [x] Did I properly add Javis dependencies to the `Project.toml` + set an upper bound of the dependency (if applicable)?
- [x] Did I properly add test dependencies to the `test` directory (if applicable)?
- [x] Did I check relevant tutorials that may be affected by changes in this PR?
- [x] Did I clearly articulate why this PR was made the way it was and how it was made?

**Link to relevant issue(s)**
Closes #332


**How did you address these issues with this PR? What methods did you use?**
The problem was still that `O` can be confused with `0` easily. Now it should be very clear due to both the word `letter` as well as mentioning that it stands for `origin`.


