### PR TITLE
Flexible extension to RFrames

### DIFF
--- a/src/Javis.jl
+++ b/src/Javis.jl
@@ -424,6 +424,7 @@ export rev
 export scaleto
 export act!
 export anim_translate, anim_rotate, anim_rotate_around, anim_scale
+export default_last, prev_start, prev_last, parent_start, parent_last
 
 # custom override of luxor extensions
 export setline, setopacity, fontsize, get_fontsize, scale, text

--- a/src/structs/Frames.jl
+++ b/src/structs/Frames.jl
@@ -67,7 +67,7 @@ end
 """
     get_frames(parent, elem, relative::RFrames, last_frames::UnitRang; is_first=falsee)
 
-Return the frames based on a relative frames [`RFrames`](@ref) object and the `last_frames`.
+Return the frames based on a relative frames [`RFrames`](@ref) object using `RFrames.start` or `RFrames.last`.
 """
 function get_frames(
     parent,
@@ -76,8 +76,9 @@ function get_frames(
     last_frames::UnitRange;
     is_first = false,
 )
-    start_frame = last(last_frames) + first(relative.frames)
-    last_frame = last(last_frames) + last(relative.frames)
+    start_frame =
+        relative.start(parent, elem, relative, last_frames) + first(relative.frames)
+    last_frame = relative.last(parent, elem, relative, last_frames)
     return start_frame:last_frame
 end
 

--- a/src/structs/RFrames.jl
+++ b/src/structs/RFrames.jl
@@ -20,9 +20,13 @@ Object(91:100, (args...)->circ("red"))
 
 # Fields
 - frames::UnitRange defines the frames in a relative fashion.
+- start::Function returns the reference global frame for the relative frame range.
+- last::Function returns the ending global frame for the relative frame range (if specified ignores the ending for `frames` feild).
 """
 struct RFrames
     frames::UnitRange
+    start::Function
+    last::Function
 end
 
 """
@@ -30,4 +34,144 @@ end
 
 Shorthand for RFrames(1:i)
 """
-RFrames(i::Int) = RFrames(1:i)
+RFrames(i::Int) = RFrames(1:i, nothing, nothing)
+RFrames(i::UnitRange) = RFrames(i, nothing, nothing)
+
+"""
+    RFrames(i::UnitRange, s::Function)
+
+Shorthand for relative frame range with the reference start frame computed during rendering i.e. `(first(i)+s):(last(i)+s)`.
+"""
+RFrames(i::UnitRange, s::Function) = RFrames(i, s, nothing)
+
+"""
+    RFrames(s::Function, e::Function)
+
+Shorthand for relative frame range with both reference start and global end frame computed during rendering.
+"""
+RFrames(s::Function, e::Function) = RFrames(0:0, s, e)
+
+"""
+    RFrames(frames::UnitRange, start, last)
+
+# Arguments
+- frames is a `UnitRange` defining the frame window relative to the starting reference frame
+- start can be a `Function` or `nothing` to support the shorthands
+    - This returns the starting reference frame number to which `frames` must be added.
+    - Examples are [`prev_start()`](@ref), [`prev_last()`](@ref) etc.
+- last can be a `Function` or `nothing` to support the shorthands
+    - This directly returns the last frame number. If specified, the end frame calculated using `start` above is ignored.
+    - Examples are [`parent_last()`](@ref), [`default_last()`](@ref) etc.
+"""
+function RFrames(frames::UnitRange, start, last)
+    if start === nothing
+        start = prev_last()
+    end
+    if last === nothing
+        last = default_last()
+    end
+    return RFrames(frames, start, last)
+end
+
+"""
+    default_last()
+
+Calculate last frame relative to end of previous frame range.
+"""
+function default_last()
+    (parent, elem, relative, last_frames) ->
+        _default_last(parent, elem, relative, last_frames)
+end
+
+function _default_last(parent, elem, relative, last_frames)
+    return relative.start(parent, elem, relative, last_frames) + last(relative.frames)
+end
+
+"""
+    prev_start()
+
+Return start frame of the previous object/action.
+"""
+function prev_start()
+    (parent, elem, relative, last_frames) ->
+        _prev_start(parent, elem, relative, last_frames)
+end
+
+function _prev_start(parent, elem, relative, last_frames)
+    return first(last_frames)
+end
+
+"""
+    prev_start(o::AbstractObject)
+
+Return start frame of the specified previous object.
+"""
+function prev_start(o::AbstractObject)
+    (args...) -> _prev_start(o)
+end
+
+function _prev_start(o::AbstractObject)
+    return first(get_frames(o))
+end
+
+"""
+    prev_last()
+
+Return last frame of the previous object/action.
+"""
+function prev_last()
+    (parent, elem, relative, last_frames) -> _prev_last(parent, elem, relative, last_frames)
+end
+
+function _prev_last(parent, elem, relative, last_frames)
+    return last(last_frames)
+end
+
+"""
+    prev_last(o::AbstractObject)
+
+Return last frame of the specified previous object.
+"""
+function prev_last(o::AbstractObject)
+    (args...) -> _prev_last(o)
+end
+
+function _prev_last(o::AbstractObject)
+    return last(get_frames(o))
+end
+
+"""
+    parent_start()
+
+Return start frame of the parent object (for actions) or background (for objects).
+"""
+function parent_start()
+    (parent, elem, relative, last_frames) ->
+        _parent_start(parent, elem, relative, last_frames)
+end
+
+function _parent_start(parent, elem, relative, last_frames)
+    if elem isa AbstractObject
+        return first(get_frames(CURRENT_VIDEO[1].objects[1]))
+    else
+        return 1
+    end
+end
+
+"""
+    parent_last()
+
+Return last frame of the parent object (for actions) or background (for objects).
+"""
+function parent_last()
+    return (parent, elem, relative, last_frames) ->
+        _parent_last(parent, elem, relative, last_frames)
+end
+
+function _parent_last(parent, elem, relative, last_frames)
+    if elem isa AbstractObject
+        return last(get_frames(CURRENT_VIDEO[1].objects[1]))
+    else
+        return last(get_frames(parent)) - first(get_frames(parent)) + 1
+    end
+end

--- a/test/frames.jl
+++ b/test/frames.jl
@@ -1,0 +1,74 @@
+@testset "Check RFrame shorthands" begin
+    function dummy(args...) end
+    video = Video(10, 10)
+    Background(1:20, dummy)
+    a = Object(1:3, (args...) -> O) # 1:3
+    b = Object(RFrames(1:3), (args...) -> O) # 4:6
+    c = Object(RFrames(1:3, prev_start()), (args...) -> O) # 5:7
+    d = Object(RFrames(prev_start(), prev_last()), (args...) -> O) # 5:7
+    render(video; tempdirectory = "images", pathname = "")
+    @test a.frames.frames == 1:3
+    @test b.frames.frames == 4:6
+    @test c.frames.frames == 5:7
+    @test d.frames.frames == 5:7
+end
+
+@testset "Check RFrame helper function for previous object" begin
+    function dummy(args...) end
+    video = Video(10, 10)
+    Background(1:20, dummy)
+    a = Object(1:3, (args...) -> O) # 1:3
+    b = Object(RFrames(2:5, prev_start(), default_last()), (args...) -> O) # 3:6
+    c = Object(RFrames(2:5, prev_last()), (args...) -> O) # 8:11
+    d = Object(RFrames(0:3, prev_start(c)), (args...) -> O) # 8:11
+    e = Object(RFrames(2:5, prev_last(b)), (args...) -> O) # 8:11
+    render(video; tempdirectory = "images", pathname = "")
+    @test a.frames.frames == 1:3
+    @test b.frames.frames == 3:6
+    @test c.frames.frames == 8:11
+    @test d.frames.frames == 8:11
+    @test e.frames.frames == 8:11
+end
+
+@testset "Check RFrame helper function for previous action" begin
+    function dummy(args...) end
+    video = Video(10, 10)
+    Background(1:20, dummy)
+    a = Object(3:15, (args...) -> O) # 3:15
+    act!(a, Action(1:3, appear(:fade))) # 1:3
+    act!(a, Action(RFrames(2:5, prev_start()), appear(:fade))) # 3:6
+    act!(a, Action(RFrames(2:5, prev_last()), appear(:fade))) # 8:11
+    render(video; tempdirectory = "images", pathname = "")
+    @test a.frames.frames == 3:15
+    @test a.actions[1].frames.frames == 1:3
+    @test a.actions[2].frames.frames == 3:6
+    @test a.actions[3].frames.frames == 8:11
+end
+
+@testset "Check RFrame helper function parent_start and parent_last for object" begin
+    function dummy(args...) end
+    video = Video(10, 10)
+    Background(1:20, dummy)
+    a = Object(3:15, (args...) -> O) # 3:15
+    b = Object(RFrames(-5:0, parent_last()), (args...) -> O) # last 5 frames of video i.e. 15:20
+    c = Object(RFrames(5:10, parent_start()), (args...) -> O) # after first 5 frames of video i.e. 6:11
+    render(video; tempdirectory = "images", pathname = "")
+    @test a.frames.frames == 3:15
+    @test b.frames.frames == 15:20
+    @test c.frames.frames == 6:11
+end
+
+@testset "Check RFrame helper function parent_start and parent_last for action" begin
+    function dummy(args...) end
+    video = Video(10, 10)
+    Background(1:20, dummy)
+    a = Object(1:15, (args...) -> O) # 1:15
+    act!(a, Action(RFrames(0:4, parent_start()), appear(:fade))) # 1:5 relative to parent
+    act!(a, Action(RFrames(5:10, prev_last(), parent_last()), disappear(:fade))) # 10:15 relative to parent
+    act!(a, Action(RFrames(-5:0, parent_last()), disappear(:scale))) # 10:15 relative to parent
+    render(video; tempdirectory = "images", pathname = "")
+    @test a.frames.frames == 1:15
+    @test a.actions[1].frames.frames == 1:5
+    @test a.actions[2].frames.frames == 10:15
+    @test a.actions[3].frames.frames == 10:15
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,6 +37,9 @@ end
 @testset "Unit" begin
     include("unit.jl")
 end
+@testset "Frames" begin
+    include("frames.jl")
+end
 @testset "SVG LaTeX tests" begin
     include("svg.jl")
 end


### PR DESCRIPTION
## PR Checklist

If you are contributing to `Javis.jl`, please make sure you are able to check off each item on this list:

- [ ] Did I update `CHANGELOG.md` with whatever changes/features I added with this PR?
- [x] Did I make sure to only change the part of the file where I introduced a new change/feature?
- [x] Did I cover all corner cases to be close to 100% test coverage (if applicable)?
- [ ] Did I properly add Javis dependencies to the `Project.toml` + set an upper bound of the dependency (if applicable)?
- [x] Did I properly add test dependencies to the `test` directory (if applicable)?
- [x] Did I check relevant tutorials that may be affected by changes in this PR?
- [x] Did I clearly articulate why this PR was made the way it was and how it was made?

**Link to relevant issue(s)**
Closes #331 


**How did you address these issues with this PR? What methods did you use?**
As discussed in the issue there were 2 approaches to make `RFrames` more flexible. One was to supply additional flags to accommodate the different cases. Other is to let the user specify the starting reference and (optionally) the end frame. 
The latter allows a wide range of options like specifying the frame range based on a previously created object.
Any suggestions @Wikunia @TheCedarPrince @Sov-trotter ?

