### PR TITLE
[GSoC'21] Layers in Javis

### DIFF
--- a/src/Javis.jl
+++ b/src/Javis.jl
@@ -52,9 +52,9 @@ Transformation(p, a) = Transformation(p, a, 1.0)
 Transformation(p, a, s::Float64) = Transformation(p, a, (s, s))
 Transformation(p, a, s::Tuple{Float64,Float64}) = Transformation(p, a, Scale(s...))
 
-include("structs/Layer.jl")
 include("structs/ObjectSetting.jl")
 include("structs/Object.jl")
+include("structs/Layer.jl")
 include("structs/Transitions.jl")
 include("structs/Action.jl")
 
@@ -334,7 +334,7 @@ function draw_layer(video, object::Object, frame, background_settings, origin_ma
         origin_matrix = cairotojuliamatrix(getmatrix())
         update_background_settings!(background_settings, object)    
     
-    elseif frame in get_frames(object)
+    elseif frame in get_frames(object) && frame in get(object.opts, :lifetime, frame)
         @layer begin
             update_object_settings!(object, background_settings)
             draw_object(object, video, frame, origin_matrix)
@@ -350,7 +350,7 @@ function draw_layer(video, layer::Layer, frame, background_settings, origin_matr
     # nomenclature is a headache...objects and layers are used interchangebly here.
     # update_layer_settings is what we need to give this to have awesome properties
     # but before that please have the layer positioning thing sorted out
-    if frame in get_frames(layer)
+    if frame in get_frames(layer) && frame in get(layer.misc, :lifetime, frame)
         objects = layer.children
         @layer begin
             for object in objects

--- a/src/Javis.jl
+++ b/src/Javis.jl
@@ -343,8 +343,6 @@ function draw_layer(video, object::Object, frame, background_settings, origin_ma
 end
 
 function draw_layer(video, layer::Layer, frame, background_settings, origin_matrix)
-    objects = layer.children
-
     # currently this approach is still object based
     # nothing much related to layers happens here except the higher @layer block
     # define get_frames for a layer so that the layer is not rendered beyond the frame range
@@ -352,9 +350,12 @@ function draw_layer(video, layer::Layer, frame, background_settings, origin_matr
     # nomenclature is a headache...objects and layers are used interchangebly here.
     # update_layer_settings is what we need to give this to have awesome properties
     # but before that please have the layer positioning thing sorted out
-    @layer begin
-        for object in objects
-            draw_layer(video, object, frame, background_settings, origin_matrix)
+    if frame in get_frames(layer)
+        objects = layer.children
+        @layer begin
+            for object in objects
+                draw_layer(video, object, frame, background_settings, origin_matrix)
+            end
         end
     end
 end

--- a/src/Javis.jl
+++ b/src/Javis.jl
@@ -348,13 +348,7 @@ function draw_layer(video, layer::Layer, frame, background_settings, origin_matr
     CURRENT_LAYER[1] = layer
     cls = get_current_layer_setting()
     !cls.show_object && return
-    # currently this approach is still object based
-    # nothing much related to layers happens here except the higher @layer block
-    # define get_frames for a layer so that the layer is not rendered beyond the frame range
     
-    # nomenclature is a headache...objects and layers are used interchangebly here.
-    # update_layer_settings is what we need to give this to have awesome properties
-    # but before that please have the layer positioning thing sorted out
     if frame in get_frames(layer) && frame in get(layer.misc, :lifetime, frame)
         objects = layer.children
         cls.hue != "" && sethue(cls.hue)
@@ -365,22 +359,6 @@ function draw_layer(video, layer::Layer, frame, background_settings, origin_matr
         end
     end
 end
-
-# this is what luxor does
-# so we can translate the layer to a specific pos
-#     @layer begin
-#         translate(pos) -----------|  
-#         setline(0.5)   -----------|
-#         sethue("black")-----------|>> we will have to do this to implement the properties for every layer
-#         box(O, w, h, :stroke)-----|
-#         sethue("purple")----------|
-#         for i in 0:0.005:1.0
-#             circle(Point(-w/2, h/2) + Point(w * i, -f(i, 0, h, 1)), 1, :fill)
-#         end
-#         sethue("black")
-#         text(replace(string(f), "Luxor." => ""), Point(0, h/2 - 20), halign=:center)
-#     end
-# end    
 
 """
     draw_object(object, video, frame, origin_matrix)

--- a/src/action_animations.jl
+++ b/src/action_animations.jl
@@ -154,6 +154,11 @@ function _translate(video, object, action, rel_frame)
     Luxor.translate(p)
 end
 
+function _translate(video, layer::Layer, action, rel_frame)
+    p = get_interpolation(action, rel_frame)
+    layer.position = p
+end
+
 """
     rotate()
 
@@ -259,6 +264,11 @@ end
 function _scale(video, object, action, rel_frame)
     s = get_interpolation(action, rel_frame)
     scaleto(s)
+end
+
+function _scale(video, layer::Layer, action, rel_frame)
+    s = get_interpolation(action, rel_frame)
+    layer.current_setting.scale = s
 end
 
 """

--- a/src/structs/Layer.jl
+++ b/src/structs/Layer.jl
@@ -21,9 +21,21 @@ function to_layer!(layer::Layer, frames, obj::Union{AbstractObject, Vector{<:Abs
     # add other properties if any
 end
 
-to_layer!(layer::Layer, obj::AbstractObject) = push!(layer.children, obj)
-to_layer!(layer::Layer, obj::Vector{<:AbstractObject}) = push!(layer.children, obj...)# removes the object from orphanObjects
+function to_layer!(layer::Layer, obj::Vector{<:AbstractObject}) 
+    for o in obj
+        to_layer!(layer, o)
+    end
+end
 
+to_layer!(layer::Layer, obj::Object) = push!(layer.children, obj)
+
+#removes the layer from the children field if that layer is made a child of another layer
+function to_layer!(layer::Layer, lyr::Layer)
+    filter!(x->x≠lyr,CURRENT_VIDEO[1].layers)
+    push!(layer.children, lyr)
+end
+
+# removes the object from orphanObjects
 function adopt!(orphan_objects::Vector{AbstractObject}, obj::AbstractObject)
     filter!(x->x≠obj,orphan_objects)
 end

--- a/src/structs/Layer.jl
+++ b/src/structs/Layer.jl
@@ -10,16 +10,8 @@ end
 
 const CURRENT_LAYER = Array{Layer,1}()
 
-#the frames specified in the to_layer! method are a bit 
-#too much since we already define the frame range for objects and layers
-#let's make this optional and have the default fetch that the object's frame range
 function to_layer!(layer::Layer, lifetime, objects::Union{AbstractObject, Vector{<:AbstractObject}})
-    # orphan objects are the objects that may or maynot be adopted into a layer 
-    # Needs a Better nomenclature
-    # this is an expensive operation
-    # we can get rid of the orphanObjects field and have such objects sit in the layers field in Video
-    # but just to have clarity right now let's keep them separate
-    
+    # orphan objects may or may not be adopted into a layer 
     orphan_objects = CURRENT_VIDEO[1].orphanObjects
     adopt!(orphan_objects, objects)
     
@@ -32,7 +24,6 @@ function to_layer!(layer::Layer, lifetime, objects::Union{AbstractObject, Vector
     for object in objects
         to_layer!(layer, lifetime, object)
     end
-    # add other properties if any
 end
 
 function to_layer!(layer::Layer, lifetime, object::Object)
@@ -54,11 +45,6 @@ end
 function adopt!(orphan_objects::Vector{AbstractObject}, obj::Vector{<:AbstractObject})
     filter!(x->x∉obj,orphan_objects)
 end
-
-# make width and height Optional
-# fetch from video by default
-# if width and height are different from that in the video
-# specify the position of the layer
 
 function Layer(frames; width = CURRENT_VIDEO[1].width, height = CURRENT_VIDEO[1].width, position = O, layer_setting::LayerSetting = LayerSetting(), misc = Dict{Symbol, Any}())
     layer = Layer(frames, width, height, AbstractObject[], position, layer_setting, misc)
@@ -83,12 +69,3 @@ end
 #     Javis.CURRENT_VIDEO[1].layers[1].children = AbstractObject[]
 #     Javis.CURRENT_LAYER[1].children = AbstractObject[]
 # end
-
-
-
-
-# if width != CURRENT_VIDEO[1].width || height != CURRENT_VIDEO[1].height
-    #     @warn(
-    #         "You didn't specify the position of layer on the canvas. Translating to origin."
-    #     )
-    # end

--- a/src/structs/Layer.jl
+++ b/src/structs/Layer.jl
@@ -10,6 +10,11 @@ end
 const CURRENT_LAYER = Array{Layer,1}()
 
 function to_layer!(layer::Layer, frames, obj::Union{AbstractObject, Vector{<:AbstractObject}})
+    # orphan objects are the objects that may or maynot be adopted into a layer 
+    # Better nomenclature please
+    # this is an expensive operation
+    # we can get rid of the orphanObjects field and have such objects sit in the layers field in Video
+    # but just to have clarity right now let's keep them separate
     orphan_objects = CURRENT_VIDEO[1].orphanObjects
     adopt!(orphan_objects, obj)
     to_layer!(layer, obj)
@@ -20,7 +25,7 @@ to_layer!(layer::Layer, obj::AbstractObject) = push!(layer.children, obj)
 to_layer!(layer::Layer, obj::Vector{<:AbstractObject}) = push!(layer.children, obj...)# removes the object from orphanObjects
 
 function adopt!(orphan_objects::Vector{AbstractObject}, obj::AbstractObject)
-    filter!(x->x≠"s",orphan_objects)
+    filter!(x->x≠obj,orphan_objects)
 end
 function adopt!(orphan_objects::Vector{AbstractObject}, obj::Vector{<:AbstractObject})
     filter!(x->x∉obj,orphan_objects)
@@ -44,15 +49,16 @@ function Layer(frames, width = CURRENT_VIDEO[1].width, height = CURRENT_VIDEO[1]
     empty!(CURRENT_OBJECT)
     return layer
 end
-"""
-Removes objects from the layer
-also from the video
-todo: clear other fields too
-"""
-function clear_layer!()
-    Javis.CURRENT_VIDEO[1].layers[1].children = AbstractObject[]
-    Javis.CURRENT_LAYER[1].children = AbstractObject[]
-end
+
+# """
+# Removes objects from the layer
+# also from the video
+# todo: clear other fields too
+# """
+# function clear_layer!()
+#     Javis.CURRENT_VIDEO[1].layers[1].children = AbstractObject[]
+#     Javis.CURRENT_LAYER[1].children = AbstractObject[]
+# end
 
 
 

--- a/src/structs/Layer.jl
+++ b/src/structs/Layer.jl
@@ -1,0 +1,124 @@
+mutable struct Layer <:AbstractObject
+    frames::Frames
+    width::Int
+    height::Int
+    children::Vector{AbstractObject}
+    position::Point
+    misc::Dict{Symbol,Any}
+end
+
+const CURRENT_LAYER = Array{Layer,1}()
+
+function to_layer!(layer::Layer, frames, obj::Union{AbstractObject, Vector{<:AbstractObject}})
+    orphan_objects = CURRENT_VIDEO[1].orphanObjects
+    adopt!(orphan_objects, obj)
+    to_layer!(layer, obj)
+    # add other properties if any
+end
+
+to_layer!(layer::Layer, obj::AbstractObject) = push!(layer.children, obj)
+to_layer!(layer::Layer, obj::Vector{<:AbstractObject}) = push!(layer.children, obj...)# removes the object from orphanObjects
+
+function adopt!(orphan_objects::Vector{AbstractObject}, obj::AbstractObject)
+    filter!(x->x≠"s",orphan_objects)
+end
+function adopt!(orphan_objects::Vector{AbstractObject}, obj::Vector{<:AbstractObject})
+    filter!(x->x∉obj,orphan_objects)
+end
+
+# make width and height Optional
+# fetch from video by default
+# if width and height are different from that in the video
+# specify the position of the layer
+
+function Layer(frames, width = CURRENT_VIDEO[1].width, height = CURRENT_VIDEO[1].width, position = O; misc = Dict())
+    layer = Layer(frames, width, height, AbstractObject[], position, misc)
+
+    if isempty(CURRENT_LAYER)
+        push!(CURRENT_LAYER, layer)
+    else
+        CURRENT_LAYER[1] = layer
+    end
+    push!(CURRENT_VIDEO[1].layers, layer)
+
+    empty!(CURRENT_OBJECT)
+    return layer
+end
+"""
+Removes objects from the layer
+also from the video
+todo: clear other fields too
+"""
+function clear_layer!()
+    Javis.CURRENT_VIDEO[1].layers[1].children = AbstractObject[]
+    Javis.CURRENT_LAYER[1].children = AbstractObject[]
+end
+
+
+
+
+# if width != CURRENT_VIDEO[1].width || height != CURRENT_VIDEO[1].height
+    #     @warn(
+    #         "You didn't specify the position of layer on the canvas. Translating to origin."
+    #     )
+    # end
+    
+
+
+
+
+
+
+
+
+
+
+#todo
+# figure out if we need a layer setting 
+# also in other places instead of fetching the global background layer
+# fetch stuff from the CURRENT_LAYER if a layer is defined
+
+# mutable struct LayerSetting
+#     line_width::Float64
+#     mul_line_width::Float64 # the multiplier of line width is between 0 and 1
+#     opacity::Float64
+#     mul_opacity::Float64 # the multiplier of opacity is between 0 and 1
+#     fontsize::Float64
+#     # scale has three fields instead of just the normal two
+#     # current scale
+#     # desired scale and scale multiplier => `desired_scale*mul_scale` is the new desired scale
+#     # the scale change needs to be computed using `current_scale` and the desired scale
+#     # current_scale should never be 0 as this breaks scaleto has various other bad effects
+#     # see: https://github.com/JuliaGraphics/Luxor.jl/issues/114
+#     # in this case show will be set to false and the object will not be called
+#     show_object::Bool
+#     current_scale::Scale
+#     desired_scale::Scale
+#     mul_scale::Float64 # the multiplier of scale is between 0 and 1
+
+#     ObjectSetting() =
+#         new(1.0, 1.0, 1.0, 1.0, 10.0, true, Scale(1.0, 1.0), Scale(1.0, 1.0), 1.0)
+# end
+
+# function update_LayerSetting!(as::LayerSetting, by::LayerSetting)
+#     as.line_width = by.line_width
+#     as.mul_line_width = by.mul_line_width
+#     as.opacity = by.opacity
+#     as.mul_opacity = by.mul_opacity
+#     as.fontsize = by.fontsize
+#     as.show_object = by.show_object
+#     as.current_scale = by.current_scale
+#     as.desired_scale = by.desired_scale
+#     as.mul_scale = by.mul_scale
+# end
+
+# function update_background_settings!(setting::LayerSetting, object::AbstractObject)
+#     in_global_layer = get(object.opts, :in_global_layer, false)
+#     if in_global_layer
+#         update_ObjectSetting!(setting, object.current_setting)
+#     end
+# end
+
+# function update_layer_settings!(layer::AbstractObject, setting::LayerSetting)
+#     update_LayerSetting!(layer.current_setting, setting)
+# end

--- a/src/structs/Layer.jl
+++ b/src/structs/Layer.jl
@@ -2,52 +2,18 @@ mutable struct Layer <:AbstractObject
     frames::Frames
     width::Int
     height::Int
-    children::Vector{AbstractObject}
     position::Point
+    children::Vector{AbstractObject}
+    actions::Vector{AbstractAction}
     current_setting::LayerSetting
-    misc::Dict{Symbol,Any} # rename this to opts
+    misc::Dict{Symbol,Any}
+    image_matrix::Vector{Any}
 end
 
 const CURRENT_LAYER = Array{Layer,1}()
 
-function to_layer!(layer::Layer, lifetime, objects::Union{AbstractObject, Vector{<:AbstractObject}})
-    # orphan objects may or may not be adopted into a layer 
-    orphan_objects = CURRENT_VIDEO[1].orphanObjects
-    adopt!(orphan_objects, objects)
-    
-    layer_frames = layer.frames.frames
-    if layer_frames.start > lifetime.start || layer_frames.stop < lifetime.stop
-        @warn "Object/Layer exists outside the frame range of the layer. Using the layer framerange as the Object lifetime" 
-        lifetime = layer_frames
-    end
-
-    for object in objects
-        to_layer!(layer, lifetime, object)
-    end
-end
-
-function to_layer!(layer::Layer, lifetime, object::Object)
-    push!(layer.children, object)
-    push!(object.opts, (:lifetime => lifetime))
-end
-
-function to_layer!(layer::Layer, lifetime, lyr::Layer)
-    filter!(x->x≠lyr,CURRENT_VIDEO[1].layers)
-    update_layer_settings!(lyr, layer.current_setting)
-    push!(layer.children, lyr)
-    push!(layer.misc, (:lifetime => lifetime))
-end
-
-# removes the object from orphanObjects
-function adopt!(orphan_objects::Vector{AbstractObject}, obj::AbstractObject)
-    filter!(x->x≠obj,orphan_objects)
-end
-function adopt!(orphan_objects::Vector{AbstractObject}, obj::Vector{<:AbstractObject})
-    filter!(x->x∉obj,orphan_objects)
-end
-
-function Layer(frames; width = CURRENT_VIDEO[1].width, height = CURRENT_VIDEO[1].width, position = O, layer_setting::LayerSetting = LayerSetting(), misc = Dict{Symbol, Any}())
-    layer = Layer(frames, width, height, AbstractObject[], position, layer_setting, misc)
+function Layer(frames; width = CURRENT_VIDEO[1].width, height = CURRENT_VIDEO[1].height, position = O, children = AbstractObject[], actions = AbstractAction[], setting = LayerSetting(), misc = Dict{Symbol, Any}(), mat = Any[nothing])
+    layer = Layer(frames, width, height, position, children, actions, setting, misc, mat)
 
     if isempty(CURRENT_LAYER)
         push!(CURRENT_LAYER, layer)
@@ -56,16 +22,96 @@ function Layer(frames; width = CURRENT_VIDEO[1].width, height = CURRENT_VIDEO[1]
     end
     push!(CURRENT_VIDEO[1].layers, layer)
 
-    empty!(CURRENT_OBJECT)
+    empty!(CURRENT_LAYER)
     return layer
 end
 
+function javis_layer(frames, width, height, position, objects)
+    filter!(x->x∉objects, CURRENT_VIDEO[1].objects) # remove objects that belong to a layer from video.objects
+    return Layer(frames, width = width, height = height, position = position, children = objects)    
+end
+
+function layer_act!(layer::Layer, action::AbstractAction)
+    push!(layer.actions, copy(action))
+end
+
+function layer_act!(layer::Layer, actions::Vector{<:AbstractAction})
+    for action in actions
+        layer_act!(layer, action)
+    end
+end
+
+function layer_act!(layers::Vector{<:Layer}, action)
+    for layer in objects
+        layer_act!(layer, action)
+    end
+end
+
+
+
+
+# julia> @imagematrix begin
+#     sethue(1., 0.5, 0.0)
+# paint()
+# end 2 2
+# 2×2 reinterpret(ARGB32, ::Array{UInt32,2}):
+# ARGB32(1.0,0.502,0.0,1.0)  ARGB32(1.0,0.502,0.0,1.0)
+# ARGB32(1.0,0.502,0.0,1.0)  ARGB32(1.0,0.502,0.0,1.0)
+# ```
+# picks up the default alpha of 1.0.
 # """
-# Removes objects from the layer
-# also from the video
-# todo: clear other fields too
-# """
-# function clear_layer!()
-#     Javis.CURRENT_VIDEO[1].layers[1].children = AbstractObject[]
-#     Javis.CURRENT_LAYER[1].children = AbstractObject[]
+# macro imagematrix(body, width=256, height=256)
+# quote
+#  Drawing($(esc(width)), $(esc(height)), :image)
+#  origin()
+#  $(esc(body))
+#  m = image_as_matrix()
+#  finish()
+#  m
 # end
+# end
+
+# macro javis_layer(frames, width, height, position, objects)
+
+#     filter!(x->x∉esc(objects), CURRENT_VIDEO[1].objects) # remove objects that belong to a layer from video.objects
+#     l = Layer(frames, width = width, height = height, position = position, children = objects)
+#     return l    
+# end
+
+
+# function to_layer!(layer::Layer, lifetime, objects::Union{AbstractObject, Vector{<:AbstractObject}})
+#     # orphan objects may or may not be adopted into a layer 
+#     orphan_objects = CURRENT_VIDEO[1].orphanObjects
+#     adopt!(orphan_objects, objects)
+    
+#     layer_frames = layer.frames.frames
+#     if layer_frames.start > lifetime.start || layer_frames.stop < lifetime.stop
+#         @warn "Object/Layer exists outside the frame range of the layer. Using the layer framerange as the Object lifetime" 
+#         lifetime = layer_frames
+#     end
+
+#     for object in objects
+#         to_layer!(layer, lifetime, object)
+#     end
+# end
+
+# function to_layer!(layer::Layer, lifetime, object::Object)
+#     push!(layer.children, object)
+#     push!(object.opts, (:lifetime => lifetime))
+# end
+
+# function to_layer!(layer::Layer, lifetime, lyr::Layer)
+#     filter!(x->x≠lyr,CURRENT_VIDEO[1].layers)
+#     update_layer_settings!(lyr, layer.current_setting)
+#     push!(layer.children, lyr)
+#     push!(layer.misc, (:lifetime => lifetime))
+# end
+
+# removes the object from orphanObjects
+# function adopt!(orphan_objects::Vector{AbstractObject}, obj::AbstractObject)
+#     filter!(x->x≠obj,orphan_objects)
+# end
+# function adopt!(orphan_objects::Vector{AbstractObject}, obj::Vector{<:AbstractObject})
+#     filter!(x->x∉obj,orphan_objects)
+# end
+

--- a/src/structs/Layer.jl
+++ b/src/structs/Layer.jl
@@ -4,6 +4,7 @@ mutable struct Layer <:AbstractObject
     height::Int
     children::Vector{AbstractObject}
     position::Point
+    current_setting::LayerSetting
     misc::Dict{Symbol,Any} # rename this to opts
 end
 
@@ -14,7 +15,7 @@ const CURRENT_LAYER = Array{Layer,1}()
 #let's make this optional and have the default fetch that the object's frame range
 function to_layer!(layer::Layer, lifetime, objects::Union{AbstractObject, Vector{<:AbstractObject}})
     # orphan objects are the objects that may or maynot be adopted into a layer 
-    # Better nomenclature please
+    # Needs a Better nomenclature
     # this is an expensive operation
     # we can get rid of the orphanObjects field and have such objects sit in the layers field in Video
     # but just to have clarity right now let's keep them separate
@@ -41,6 +42,7 @@ end
 
 function to_layer!(layer::Layer, lifetime, lyr::Layer)
     filter!(x->x≠lyr,CURRENT_VIDEO[1].layers)
+    update_layer_settings!(lyr, layer.current_setting)
     push!(layer.children, lyr)
     push!(layer.misc, (:lifetime => lifetime))
 end
@@ -58,8 +60,8 @@ end
 # if width and height are different from that in the video
 # specify the position of the layer
 
-function Layer(frames, width = CURRENT_VIDEO[1].width, height = CURRENT_VIDEO[1].width, position = O; misc = Dict{Symbol, Any}())
-    layer = Layer(frames, width, height, AbstractObject[], position, misc)
+function Layer(frames; width = CURRENT_VIDEO[1].width, height = CURRENT_VIDEO[1].width, position = O, layer_setting::LayerSetting = LayerSetting(), misc = Dict{Symbol, Any}())
+    layer = Layer(frames, width, height, AbstractObject[], position, layer_setting, misc)
 
     if isempty(CURRENT_LAYER)
         push!(CURRENT_LAYER, layer)
@@ -90,63 +92,3 @@ end
     #         "You didn't specify the position of layer on the canvas. Translating to origin."
     #     )
     # end
-    
-
-
-
-
-
-
-
-
-
-
-#todo
-# figure out if we need a layer setting 
-# also in other places instead of fetching the global background layer
-# fetch stuff from the CURRENT_LAYER if a layer is defined
-
-# mutable struct LayerSetting
-#     line_width::Float64
-#     mul_line_width::Float64 # the multiplier of line width is between 0 and 1
-#     opacity::Float64
-#     mul_opacity::Float64 # the multiplier of opacity is between 0 and 1
-#     fontsize::Float64
-#     # scale has three fields instead of just the normal two
-#     # current scale
-#     # desired scale and scale multiplier => `desired_scale*mul_scale` is the new desired scale
-#     # the scale change needs to be computed using `current_scale` and the desired scale
-#     # current_scale should never be 0 as this breaks scaleto has various other bad effects
-#     # see: https://github.com/JuliaGraphics/Luxor.jl/issues/114
-#     # in this case show will be set to false and the object will not be called
-#     show_object::Bool
-#     current_scale::Scale
-#     desired_scale::Scale
-#     mul_scale::Float64 # the multiplier of scale is between 0 and 1
-
-#     ObjectSetting() =
-#         new(1.0, 1.0, 1.0, 1.0, 10.0, true, Scale(1.0, 1.0), Scale(1.0, 1.0), 1.0)
-# end
-
-# function update_LayerSetting!(as::LayerSetting, by::LayerSetting)
-#     as.line_width = by.line_width
-#     as.mul_line_width = by.mul_line_width
-#     as.opacity = by.opacity
-#     as.mul_opacity = by.mul_opacity
-#     as.fontsize = by.fontsize
-#     as.show_object = by.show_object
-#     as.current_scale = by.current_scale
-#     as.desired_scale = by.desired_scale
-#     as.mul_scale = by.mul_scale
-# end
-
-# function update_background_settings!(setting::LayerSetting, object::AbstractObject)
-#     in_global_layer = get(object.opts, :in_global_layer, false)
-#     if in_global_layer
-#         update_ObjectSetting!(setting, object.current_setting)
-#     end
-# end
-
-# function update_layer_settings!(layer::AbstractObject, setting::LayerSetting)
-#     update_LayerSetting!(layer.current_setting, setting)
-# end

--- a/src/structs/Layer.jl
+++ b/src/structs/Layer.jl
@@ -9,7 +9,12 @@ end
 
 const CURRENT_LAYER = Array{Layer,1}()
 
-function to_layer!(layer::Layer, frames, obj::Union{AbstractObject, Vector{<:AbstractObject}})
+
+#the frames specified in the to_layer! method are a bit 
+#too much since we already define the frame range for objects and layers
+#let's make this optional and have the default fetch that the object's frame range
+
+function to_layer!(layer::Layer, obj::Union{AbstractObject, Vector{<:AbstractObject}})
     # orphan objects are the objects that may or maynot be adopted into a layer 
     # Better nomenclature please
     # this is an expensive operation
@@ -21,13 +26,13 @@ function to_layer!(layer::Layer, frames, obj::Union{AbstractObject, Vector{<:Abs
     # add other properties if any
 end
 
-function to_layer!(layer::Layer, obj::Vector{<:AbstractObject}) 
-    for o in obj
-        to_layer!(layer, o)
+function to_layer!(layer::Layer, objects::Vector{<:AbstractObject}) 
+    for object in objects
+        to_layer!(layer, object)
     end
 end
 
-to_layer!(layer::Layer, obj::Object) = push!(layer.children, obj)
+to_layer!(layer::Layer, object::Object) = push!(layer.children, object)
 
 #removes the layer from the children field if that layer is made a child of another layer
 function to_layer!(layer::Layer, lyr::Layer)

--- a/src/structs/LayerSetting.jl
+++ b/src/structs/LayerSetting.jl
@@ -1,57 +1,8 @@
-# can more settings be defined for a layer?
 mutable struct LayerSetting
-    hue::String
-    line_width::Float64
-    mul_line_width::Float64 # the multiplier of line width is between 0 and 1
     opacity::Float64
-    mul_opacity::Float64 # the multiplier of opacity is between 0 and 1
-    fontsize::Float64
-    # scale has three fields instead of just the normal two
-    # current scale
-    # desired scale and scale multiplier => `desired_scale*mul_scale` is the new desired scale
-    # the scale change needs to be computed using `current_scale` and the desired scale
-    # current_scale should never be 0 as this breaks scaleto has various other bad effects
-    # see: https://github.com/JuliaGraphics/Luxor.jl/issues/114
-    # in this case show will be set to false and the object will not be called
-    show_object::Bool
-    current_scale::Scale
-    desired_scale::Scale
-    mul_scale::Float64 # the multiplier of scale is between 0 and 1
+    scale::Scale
+    rotation::Float64
 
     LayerSetting() =
-        new("", 1.0, 1.0, 1.0, 1.0, 10.0, true, Scale(1.0, 1.0), Scale(1.0, 1.0), 1.0)
-end
-
-function update_LayerSetting!(as::LayerSetting, by::LayerSetting)
-    as.hue = by.hue
-    as.line_width = by.line_width
-    as.mul_line_width = by.mul_line_width
-    as.opacity = by.opacity
-    as.mul_opacity = by.mul_opacity
-    as.fontsize = by.fontsize
-    as.show_object = by.show_object
-    as.current_scale = by.current_scale
-    as.desired_scale = by.desired_scale
-    as.mul_scale = by.mul_scale
-end
-
-function update_ObjectSetting!(as::ObjectSetting, by::LayerSetting)
-    as.line_width = by.line_width
-    as.mul_line_width = by.mul_line_width
-    as.opacity = by.opacity
-    as.mul_opacity = by.mul_opacity
-    as.fontsize = by.fontsize
-    as.show_object = by.show_object
-    as.current_scale = by.current_scale
-    as.desired_scale = by.desired_scale
-    as.mul_scale = by.mul_scale
-end
-
-function update_layer_settings!(layer::AbstractObject, setting::LayerSetting)
-    update_LayerSetting!(layer.current_setting, setting)
-end
-
-
-function update_object_settings!(object::AbstractObject, setting::LayerSetting)
-    update_ObjectSetting!(object.current_setting, setting)
+        new(1.0, Scale(1.0, 1.0), 0.0)
 end

--- a/src/structs/LayerSetting.jl
+++ b/src/structs/LayerSetting.jl
@@ -1,8 +1,4 @@
-#todo
-# figure out if we need a layer setting 
-# also in other places instead of fetching the global background layer
-# fetch stuff from the CURRENT_LAYER if a layer is defined
-
+# can more settings be defined for a layer?
 mutable struct LayerSetting
     hue::String
     line_width::Float64

--- a/src/structs/LayerSetting.jl
+++ b/src/structs/LayerSetting.jl
@@ -1,0 +1,61 @@
+#todo
+# figure out if we need a layer setting 
+# also in other places instead of fetching the global background layer
+# fetch stuff from the CURRENT_LAYER if a layer is defined
+
+mutable struct LayerSetting
+    hue::String
+    line_width::Float64
+    mul_line_width::Float64 # the multiplier of line width is between 0 and 1
+    opacity::Float64
+    mul_opacity::Float64 # the multiplier of opacity is between 0 and 1
+    fontsize::Float64
+    # scale has three fields instead of just the normal two
+    # current scale
+    # desired scale and scale multiplier => `desired_scale*mul_scale` is the new desired scale
+    # the scale change needs to be computed using `current_scale` and the desired scale
+    # current_scale should never be 0 as this breaks scaleto has various other bad effects
+    # see: https://github.com/JuliaGraphics/Luxor.jl/issues/114
+    # in this case show will be set to false and the object will not be called
+    show_object::Bool
+    current_scale::Scale
+    desired_scale::Scale
+    mul_scale::Float64 # the multiplier of scale is between 0 and 1
+
+    LayerSetting() =
+        new("", 1.0, 1.0, 1.0, 1.0, 10.0, true, Scale(1.0, 1.0), Scale(1.0, 1.0), 1.0)
+end
+
+function update_LayerSetting!(as::LayerSetting, by::LayerSetting)
+    as.hue = by.hue
+    as.line_width = by.line_width
+    as.mul_line_width = by.mul_line_width
+    as.opacity = by.opacity
+    as.mul_opacity = by.mul_opacity
+    as.fontsize = by.fontsize
+    as.show_object = by.show_object
+    as.current_scale = by.current_scale
+    as.desired_scale = by.desired_scale
+    as.mul_scale = by.mul_scale
+end
+
+function update_ObjectSetting!(as::ObjectSetting, by::LayerSetting)
+    as.line_width = by.line_width
+    as.mul_line_width = by.mul_line_width
+    as.opacity = by.opacity
+    as.mul_opacity = by.mul_opacity
+    as.fontsize = by.fontsize
+    as.show_object = by.show_object
+    as.current_scale = by.current_scale
+    as.desired_scale = by.desired_scale
+    as.mul_scale = by.mul_scale
+end
+
+function update_layer_settings!(layer::AbstractObject, setting::LayerSetting)
+    update_LayerSetting!(layer.current_setting, setting)
+end
+
+
+function update_object_settings!(object::AbstractObject, setting::LayerSetting)
+    update_ObjectSetting!(object.current_setting, setting)
+end

--- a/src/structs/Object.jl
+++ b/src/structs/Object.jl
@@ -92,11 +92,8 @@ function Object(frames, func::Function, start_pos::Union{Object,Point}; kwargs..
         Dict{Symbol,Any}(),
         Any[nothing],
     )
-    if get(opts, :in_global_layer, false)
-        push!(CURRENT_VIDEO[1].layers, object)
-    else
-        push!(CURRENT_VIDEO[1].orphanObjects, object)
-    end
+    # ground is always an orphan object
+    push!(CURRENT_VIDEO[1].orphanObjects, object) 
     return object
 end
 

--- a/src/structs/Object.jl
+++ b/src/structs/Object.jl
@@ -73,6 +73,8 @@ function Object(frames, func::Function, start_pos::Union{Object,Point}; kwargs..
     if isempty(CURRENT_VIDEO)
         throw(ErrorException("A `Video` must be defined before an `Object`"))
     end
+    
+
     CURRENT_VIDEO[1].defs[:last_frames] = frames
     opts = Dict(kwargs...)
 
@@ -90,7 +92,11 @@ function Object(frames, func::Function, start_pos::Union{Object,Point}; kwargs..
         Dict{Symbol,Any}(),
         Any[nothing],
     )
-    push!(CURRENT_VIDEO[1].objects, object)
+    if get(opts, :in_global_layer, false)
+        push!(CURRENT_VIDEO[1].layers, object)
+    else
+        push!(CURRENT_VIDEO[1].orphanObjects, object)
+    end
     return object
 end
 

--- a/src/structs/Object.jl
+++ b/src/structs/Object.jl
@@ -14,7 +14,7 @@ Defines what is drawn in a defined frame range.
 - `change_keywords::Dict{Symbol,Any}` the modified keywords changed by `change`
 - `result::Vector` the result of the object (if something gets returned)
 """
-struct Object <: AbstractObject
+mutable struct Object <: AbstractObject
     frames::Frames
     func::Function
     start_pos::Union{Object,Point}

--- a/src/structs/Object.jl
+++ b/src/structs/Object.jl
@@ -92,8 +92,11 @@ function Object(frames, func::Function, start_pos::Union{Object,Point}; kwargs..
         Dict{Symbol,Any}(),
         Any[nothing],
     )
-    # ground is always an orphan object
-    push!(CURRENT_VIDEO[1].orphanObjects, object) 
+
+    # if the object belongs to local layer, don't push it to the video
+    if !get(opts, :in_local_layer, false)
+        push!(CURRENT_VIDEO[1].objects, object)
+    end
     return object
 end
 
@@ -171,4 +174,9 @@ This draws a white circle on a black background as `sethue` is defined for the g
 """
 function Background(frames, func::Function, args...; kwargs...)
     Object(frames, func, args...; in_global_layer = true, kwargs...)
+end
+
+# todo apply layer brackground through this
+function LayerBackground(frames, func::Function, args...; kwargs...)
+    Object(frames, func, args...; in_local_layer = true, kwargs...)
 end

--- a/src/structs/Video.jl
+++ b/src/structs/Video.jl
@@ -13,7 +13,8 @@ Defines the video canvas for an animation.
 mutable struct Video
     width::Int
     height::Int
-    objects::Vector{AbstractObject}
+    layers::Vector{AbstractObject}
+    orphanObjects::Vector{AbstractObject} #use a better data structure here(array resizing makes allocations and takes up time)
     background_frames::Vector{Int}
     defs::Dict{Symbol,Any}
 end
@@ -36,12 +37,13 @@ This also sets `CURRENT_VIDEO`.
 function Video(width, height)
     # some luxor functions need a drawing ;)
     Drawing()
-    video = Video(width, height, AbstractObject[], Int[], Dict{Symbol,Any}())
+    video = Video(width, height, AbstractObject[], AbstractObject[],Int[], Dict{Symbol,Any}())
     if isempty(CURRENT_VIDEO)
         push!(CURRENT_VIDEO, video)
     else
         CURRENT_VIDEO[1] = video
     end
-    empty!(CURRENT_OBJECT)
+    # empty!(CURRENT_OBJECT)
+    empty!(CURRENT_LAYER)
     return video
 end

--- a/src/structs/Video.jl
+++ b/src/structs/Video.jl
@@ -43,7 +43,6 @@ function Video(width, height)
     else
         CURRENT_VIDEO[1] = video
     end
-    # empty!(CURRENT_OBJECT)
     empty!(CURRENT_LAYER)
     return video
 end

--- a/src/structs/Video.jl
+++ b/src/structs/Video.jl
@@ -13,8 +13,8 @@ Defines the video canvas for an animation.
 mutable struct Video
     width::Int
     height::Int
+    objects::Vector{AbstractObject}
     layers::Vector{AbstractObject}
-    orphanObjects::Vector{AbstractObject} #use a better data structure here(array resizing makes allocations and takes up time)
     background_frames::Vector{Int}
     defs::Dict{Symbol,Any}
 end
@@ -37,7 +37,7 @@ This also sets `CURRENT_VIDEO`.
 function Video(width, height)
     # some luxor functions need a drawing ;)
     Drawing()
-    video = Video(width, height, AbstractObject[], AbstractObject[],Int[], Dict{Symbol,Any}())
+    video = Video(width, height, AbstractObject[], AbstractObject[], Int[], Dict{Symbol,Any}())
     if isempty(CURRENT_VIDEO)
         push!(CURRENT_VIDEO, video)
     else

--- a/src/util.jl
+++ b/src/util.jl
@@ -51,6 +51,16 @@ function get_current_setting()
 end
 
 """
+    get_current_layer_setting()
+
+Return the current setting of the current layer
+"""
+function get_current_layer_setting()
+    layer = CURRENT_LAYER[1]
+    return layer.current_setting
+end
+
+"""
     get_interpolation(frames::UnitRange, frame)
 
 Return a value between 0 and 1 which represents the relative `frame` inside `frames`.


### PR DESCRIPTION
## PR Checklist

If you are contributing to `Javis.jl`, please make sure you are able to check off each item on this list:

- [ ] Did I update `CHANGELOG.md` with whatever changes/features I added with this PR?
- [ ] Did I make sure to only change the part of the file where I introduced a new change/feature?
- [ ] Did I cover all corner cases to be close to 100% test coverage (if applicable)?
- [ ] Did I properly add Javis dependencies to the `Project.toml` + set an upper bound of the dependency (if applicable)?
- [ ] Did I properly add test dependencies to the `test` directory (if applicable)?
- [ ] Did I check relevant tutorials that may be affected by changes in this PR?
- [ ] Did I clearly articulate why this PR was made the way it was and how it was made?

**Link to relevant issue(s)**
Closes #75 


**How did you address these issues with this PR? What methods did you use?**
@Wikunia @TheCedarPrince I wanted to share this small demo of the livestream feature.

Here's what it can do so far:
- [x] Implement the tree like structure we talked about 
![image](https://user-images.githubusercontent.com/43717431/120858679-c1b16600-c5a0-11eb-8198-3e9575c65503.png)
- [x] Objects can be pushed into layers and can remain outside(aka orphan objects at present; a better nomenclature would be good)
- [x] The reason to have the another field(`orphanObjects`) in the `Video` is to make the layer declaration independent of the order of declaration of objects in the animation script.
- [x] So as an object is declared, it is pushed into the `orphanObject` field. If it is pushed into a layer(using `to_layer!()`, it is moved to that layer and popped from the list of `orphanObjects`. During rendering we combine all the layers and `orphanObjects`  into a single list and pass them to the `get_javis_frames` method.
- [x] The `get_javis_frames` method looks very unorganized at this time but it will grow more as we start implementing settings on respective layers.
- [x] React to the frame range in the `layer` and `to_layer!` declaration.
 

What this demo can't do at present(but will be there in the coming days)
- [ ] React to the properties for a respective layer(object settings hue etc.)
.........etc.

[Test Script](https://gist.github.com/Sov-trotter/f8b8a7a188c4d0782e48fb2f32a9b48e)
