### PR TITLE
Render only specific frames for faster rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Javis.jl - Changelog
 
+## Unreleased
+- `frames` keyword for `render` for faster rendering
+
 ## v0.5.1
 - added support for Pluto notebooks
 - add alignment options to latex rendering


### PR DESCRIPTION
## PR Checklist

If you are contributing to `Javis.jl`, please make sure you are able to check off each item on this list:

- [x] Did I update `CHANGELOG.md` with whatever changes/features I added with this PR?
- [x] Did I make sure to only change the part of the file where I introduced a new change/feature?
- [ ] Did I cover all corner cases to be close to 100% test coverage (if applicable)?
- [ ] Did I properly add Javis dependencies to the `Project.toml` + set an upper bound of the dependency (if applicable)?
- [ ] Did I properly add test dependencies to the `test` directory (if applicable)?
- [ ] Did I check relevant tutorials that may be affected by changes in this PR?
- [ ] Did I clearly articulate why this PR was made the way it was and how it was made?

**How did you address these issues with this PR? What methods did you use?**
Render only part of the frames can speed up the rendering process. It's not that much faster unfortunately as still every frame gets computed but still.



