### PR TITLE
Luxor ambiguity clarification in howto and tutorial 1

### DIFF
--- a/docs/src/howto.md
+++ b/docs/src/howto.md
@@ -19,14 +19,15 @@ Background(1:100, ground)
 render(video; pathname="how_to.gif")
 ```
 
-## How can I avoid ambiguity errors with Luxor.jl?
+## Why are all my `Javis` functions undefined? 
 
-You might have noticed that [Luxor.jl](https://github.com/JuliaGraphics/Luxor.jl) provides the drawing functions that Javis is using.
-Javis is basically just one more package on top of it which provides functions to animate the static images you can create with Luxor.
-As one can't use Javis without using Luxor we decided to reexport all functions that Luxor exports. This means you don't have to and
-**shouldn't** call `using Luxor` as this will result in ambiguity errors. 
+If you have worked with the animation package [`Luxor.jl`](https://github.com/JuliaGraphics/Luxor.jl), you will be happy to that it provides all the drawing functions that `Javis` uses.
+`Javis` is basically an abstraction layer built on on top of `Luxor.jl` which provides functions to animate the static images you can create with `Luxor` more easily.
+As one can't use `Javis` without using Luxor we decided to reexport all functions that `Luxor` exports.
 
-Another reason we do this is the case that we sometimes need to save extra functionality when you call certain functions to have more useful information we need to create better animations. 
+This means you **should not** call `using Luxor` in scripts that use `Javis`.
+Otherwise it will result in ambiguity errors such as all the `Javis` functions being undefined when you try to run a script with `Javis` in it or other strange conflicts.
+Another reason we reexport all functions from `Luxor` is that we sometimes need to add additional `Javis` functionality around certain `Luxor` functions to create better animations.
 
 ## How can I move a circle from A to B?
 

--- a/docs/src/howto.md
+++ b/docs/src/howto.md
@@ -19,6 +19,15 @@ Background(1:100, ground)
 render(video; pathname="how_to.gif")
 ```
 
+## How can I avoid ambiguity errors with Luxor.jl?
+
+You might have noticed that [Luxor.jl](https://github.com/JuliaGraphics/Luxor.jl) provides the drawing functions that Javis is using.
+Javis is basically just one more package on top of it which provides functions to animate the static images you can create with Luxor.
+As one can't use Javis without using Luxor we decided to reexport all functions that Luxor exports. This means you don't have to and
+**shouldn't** call `using Luxor` as this will result in ambiguity errors. 
+
+Another reason we do this is the case that we sometimes need to save extra functionality when you call certain functions to have more useful information we need to create better animations. 
+
 ## How can I move a circle from A to B?
 
 First of all you need to define an [`Object`](@ref) which draws a circle.

--- a/docs/src/howto.md
+++ b/docs/src/howto.md
@@ -21,12 +21,12 @@ render(video; pathname="how_to.gif")
 
 ## Why are all my `Javis` functions undefined? 
 
-If you have worked with the animation package [`Luxor.jl`](https://github.com/JuliaGraphics/Luxor.jl), you will be happy to that it provides all the drawing functions that `Javis` uses.
+If you have worked with the Julia drawing package [`Luxor.jl`](https://github.com/JuliaGraphics/Luxor.jl), you will be happy to see that it provides all the drawing functions that `Javis` uses.
 `Javis` is basically an abstraction layer built on on top of `Luxor.jl` which provides functions to animate the static images you can create with `Luxor` more easily.
 As one can't use `Javis` without using Luxor we decided to reexport all functions that `Luxor` exports.
 
 This means you **should not** call `using Luxor` in scripts that use `Javis`.
-Otherwise it will result in ambiguity errors such as all the `Javis` functions being undefined when you try to run a script with `Javis` in it or other strange conflicts.
+Otherwise it will result in ambiguity errors such as all the `Javis` functions becoming undefined when you try to run a Julia script with `Javis` in it or other strange conflicts.
 Another reason we reexport all functions from `Luxor` is that we sometimes need to add additional `Javis` functionality around certain `Luxor` functions to create better animations.
 
 ## How can I move a circle from A to B?

--- a/docs/src/tutorials/tutorial_1.md
+++ b/docs/src/tutorials/tutorial_1.md
@@ -28,7 +28,7 @@ With all that said, let's dive into this tutorial! ✨
 `Javis.jl` is an abstraction on top of powerful graphics tools to make animations and visualizations easy to create.
 It is built on top of the fantastic Julia drawing packages, [`Luxor.jl`](https://github.com/JuliaGraphics/Luxor.jl) and [`Cairo.jl`](https://github.com/JuliaGraphics/Cairo.jl).
 `Cairo.jl` is much too complex to explain here, but `Luxor.jl` gives one the ability to define and draw on a canvas.
-`Luxor.jl` provides simple functions like `line`, `circle` and `poly` by which one can make animations. 
+`Luxor.jl` provides simple functions like `line`, `circle` and `poly` by which one can make animations. Please make sure that you not write `using Luxor` in your `Javis` scripts though as this will result in ambiguity errors. We make sure that every function you like from Luxor can be used by just calling `using Javis` :wink:
 
 > **NOTE:** If you're interested in 2D graphics, you should definitely check out the awesome `Luxor.jl` package.
 > It has a [great tutorial](https://juliagraphics.github.io/Luxor.jl/stable/tutorial/) that will give you an even greater understanding of how `Javis.jl` works.

--- a/docs/src/tutorials/tutorial_1.md
+++ b/docs/src/tutorials/tutorial_1.md
@@ -28,10 +28,16 @@ With all that said, let's dive into this tutorial! ✨
 `Javis.jl` is an abstraction on top of powerful graphics tools to make animations and visualizations easy to create.
 It is built on top of the fantastic Julia drawing packages, [`Luxor.jl`](https://github.com/JuliaGraphics/Luxor.jl) and [`Cairo.jl`](https://github.com/JuliaGraphics/Cairo.jl).
 `Cairo.jl` is much too complex to explain here, but `Luxor.jl` gives one the ability to define and draw on a canvas.
-`Luxor.jl` provides simple functions like `line`, `circle` and `poly` by which one can make animations. Please make sure that you not write `using Luxor` in your `Javis` scripts though as this will result in ambiguity errors. We make sure that every function you like from Luxor can be used by just calling `using Javis` :wink:
+`Luxor.jl` provides simple functions like `line`, `circle` and `poly` by which one can make animations.
+
+> **WARNING:** Please make sure not to use the `Luxor` package within scripts that use `Javis`!
+Do not write `using Luxor` in your `Javis` scripts or Julia REPL session as this will result in ambiguity errors.
+We make sure that every function you will need from `Luxor` can be accessed by writing `using Javis` 😉
 
 > **NOTE:** If you're interested in 2D graphics, you should definitely check out the awesome `Luxor.jl` package.
 > It has a [great tutorial](https://juliagraphics.github.io/Luxor.jl/stable/tutorial/) that will give you an even greater understanding of how `Javis.jl` works.
+
+
 
 ## Prerequisites 
 


### PR DESCRIPTION
## PR Checklist

If you are contributing to `Javis.jl`, please make sure you are able to check off each item on this list:

- [ ] Did I update `CHANGELOG.md` with whatever changes/features I added with this PR?
- [ ] Did I make sure to only change the part of the file where I introduced a new change/feature?
- [ ] Did I cover all corner cases to be close to 100% test coverage (if applicable)?
- [ ] Did I properly add Javis dependencies to the `Project.toml` + set an upper bound of the dependency (if applicable)?
- [ ] Did I properly add test dependencies to the `test` directory (if applicable)?
- [ ] Did I check relevant tutorials that may be affected by changes in this PR?
   -  all above not necessary as it's a doc change
- [x] Did I clearly articulate why this PR was made the way it was and how it was made?

**Link to relevant issue(s)**
No issue for this just from the Zulip channel

**How did you address these issues with this PR? What methods did you use?**
I've updated the HowTo section by adding a 
```
How can I avoid ambiguity errors with Luxor.jl?
```
section.

Additionally I added two sentences to the first tutorial to make clear that `using Luxor` should be avoided inside `Javis` scripts.


