### PR TITLE
Fix link to Luxor tutorial

### DIFF
--- a/docs/src/tutorials/tutorial_1.md
+++ b/docs/src/tutorials/tutorial_1.md
@@ -35,7 +35,7 @@ Do not write `using Luxor` in your `Javis` scripts or Julia REPL session as this
 We make sure that every function you will need from `Luxor` can be accessed by writing `using Javis` 😉
 
 > **NOTE:** If you're interested in 2D graphics, you should definitely check out the awesome `Luxor.jl` package.
-> It has a [great tutorial](https://juliagraphics.github.io/Luxor.jl/stable/tutorial/) that will give you an even greater understanding of how `Javis.jl` works.
+> It has a [great tutorial](http://juliagraphics.github.io/Luxor.jl/dev/tutorial/basictutorial/) that will give you an even greater understanding of how `Javis.jl` works.
 
 
 

--- a/docs/src/tutorials/tutorial_1.md
+++ b/docs/src/tutorials/tutorial_1.md
@@ -35,7 +35,7 @@ Do not write `using Luxor` in your `Javis` scripts or Julia REPL session as this
 We make sure that every function you will need from `Luxor` can be accessed by writing `using Javis` 😉
 
 > **NOTE:** If you're interested in 2D graphics, you should definitely check out the awesome `Luxor.jl` package.
-> It has a [great tutorial](http://juliagraphics.github.io/Luxor.jl/dev/tutorial/basictutorial/) that will give you an even greater understanding of how `Javis.jl` works.
+> It has a [great tutorial](http://juliagraphics.github.io/Luxor.jl/stable/tutorial/basictutorial/) that will give you an even greater understanding of how `Javis.jl` works.
 
 
 


### PR DESCRIPTION
I recently re-organized the documentation of Luxor (along `divio` lines) so any direct links you've made to individual sections of the Luxor docs, like the one in this PR, will probably 404.

Naturally I'm very sorry I've caused you extra work. :) But on the plus side, I probably won't reorganize them again for a while... 