### PR TITLE
Fix spelling error in JShape docstring

### DIFF
--- a/src/shorthands/JShape.jl
+++ b/src/shorthands/JShape.jl
@@ -13,7 +13,7 @@ end action = :stroke color = "red" radius = 8)
 ```
 
 In this example, the arguments after the `end` (i.e. `action = :stroke color = "red" radius = 8`)
-can be used inside the `bgein...end` block and animated using the [`change`](@ref) action.
+can be used inside the `begin...end` block and animated using the [`change`](@ref) action.
 """
 macro JShape(body::Expr, expr...)
     leftside = Expr(


### PR DESCRIPTION
## PR Checklist

If you are contributing to `Javis.jl`, please make sure you are able to check off each item on this list:

- [ ] Did I update `CHANGELOG.md` with whatever changes/features I added with this PR?
- [x] Did I make sure to only change the part of the file where I introduced a new change/feature?
- [x] Did I cover all corner cases to be close to 100% test coverage (if applicable)?
- [x] Did I properly add Javis dependencies to the `Project.toml` + set an upper bound of the dependency (if applicable)?
- [x] Did I properly add test dependencies to the `test` directory (if applicable)?
- [x] Did I check relevant tutorials that may be affected by changes in this PR?
- [x] Did I clearly articulate why this PR was made the way it was and how it was made?

**Link to relevant issue(s)**

**How did you address these issues with this PR? What methods did you use?**
Fixed the docstring [here](https://github.com/Wikunia/Javis.jl/blob/4dd338c53d6df5784fda4703a64d4a89b2094a18/src/shorthands/JShape.jl#L16) which replaces `bgein...end` with `begin...end`
