### PR TITLE
`JImage` Implementation for J-Objects

### DIFF
--- a/src/Javis.jl
+++ b/src/Javis.jl
@@ -682,6 +682,7 @@ include("shorthands/JEllipse.jl")
 include("shorthands/JStar.jl")
 include("shorthands/JPoly.jl")
 include("shorthands/JShape.jl")
+include("shorthands/JImage.jl")
 
 export render, latex
 export Video, Object, Background, Action, RFrames, GFrames
@@ -696,7 +697,7 @@ export act!
 export anim_translate, anim_rotate, anim_rotate_around, anim_scale
 
 export @Frames, prev_start, prev_end, startof, endof
-export JBox, JCircle, JEllipse, JLine, JPoly, JRect, JStar, @JShape
+export JBox, JCircle, JEllipse, JImage, JLine, JPoly, JRect, JStar, @JShape
 
 # custom override of luxor extensions
 export setline, setopacity, fontsize, get_fontsize, scale, text

--- a/src/shorthands/JImage.jl
+++ b/src/shorthands/JImage.jl
@@ -1,0 +1,17 @@
+function _JImage(pos, img, centering, clipargs, clipshape)
+    if clipshape != false
+        clipshape(clipargs...)
+    end
+    placeimage(img, pos, centered = centering)
+    return pos
+end
+
+JImage(pos::Point, img, centering = true; clipargs = (), clipshape = false) =
+    (
+        args...;
+        pos = pos,
+        img = img,
+        centering = centering,
+        clipargs = clipargs,
+        clipshape = clipshape,
+    ) -> _JImage(pos, img, centering, clipargs, clipshape)


### PR DESCRIPTION
## PR Checklist

If you are contributing to `Javis.jl`, please make sure you are able to check off each item on this list:

- [ ] Did I update `CHANGELOG.md` with whatever changes/features I added with this PR?
- [x] Did I make sure to only change the part of the file where I introduced a new change/feature?
- [ ] Did I cover all corner cases to be close to 100% test coverage (if applicable)?
- [x] Did I properly add Javis dependencies to the `Project.toml` + set an upper bound of the dependency (if applicable)?
- [ ] Did I properly add test dependencies to the `test` directory (if applicable)?
- [x] Did I check relevant tutorials that may be affected by changes in this PR?
- [x] Did I clearly articulate why this PR was made the way it was and how it was made?

**Link to relevant issue(s)**
Closes #388 


**How did you address these issues with this PR? What methods did you use?**

This is a proposed implementation idea for adding images to J-Objects easily. I was inspired by some of the conversation in #388 and wanted to create something easily like

```julia
function JImage(....)
     placeimage(....)
end
```

But could not get this syntax to work as when you have two separate objects - say JCircle which clips a circle shape and JImage - the clipping does occur but as JCircle does not "see" JImage, the expected output (i.e. the JImage is not clipped in a circle shape) does not occur. This PR introduces syntax such that you can write:

```julia
Object(
    JImage(
        pos = O,
        img = readpng("my_picture.png"),
        centering = true;
    ),
)
```
Which acts as a fully qualified Javis object (i.e. you can perform actions with it). Furthermore, clipping and outlining can be supported with the following kwarg syntax:

```julia
Object(
    JImage(
        pos = O,
        img = readpng("my_picture.png"),
        centering = true;
	shapeargs = (pt = O, r = 40, action = :clip),
	shape = circle,
    ),
)
```

So this picture will be cliipped by passing shapeargs and a Luxor shape function.

![jimage_test](https://user-images.githubusercontent.com/29561456/129457162-c2fafab2-fb8c-46d8-945b-91ac6c28036f.gif)

_Picture of cat from Twitch Artist ChargedAsylum and owner AftonSteps_

## Disclaimer

I have not added tests or docs as of yet as I am waiting to see what the thought is with this possible syntax.

Pinging @Wikunia and @Sov-trotter for thoughts! 