### PR TITLE
Fix documentation for get_position on Layer

### DIFF
--- a/src/layers.jl
+++ b/src/layers.jl
@@ -170,7 +170,7 @@ function show_layer_frame(
 end
 
 """
-    get_position(obj::Object)
+    get_position(l::Layer)
 
 Get access to the position of a layer.
 


### PR DESCRIPTION
## PR Checklist

If you are contributing to `Javis.jl`, please make sure you are able to check off each item on this list:

- [ ] Did I update `CHANGELOG.md` with whatever changes/features I added with this PR?
- [x] Did I make sure to only change the part of the file where I introduced a new change/feature?
- [x] Did I cover all corner cases to be close to 100% test coverage (if applicable)?
- [x] Did I properly add Javis dependencies to the `Project.toml` + set an upper bound of the dependency (if applicable)?
- [x] Did I properly add test dependencies to the `test` directory (if applicable)?
- [x] Did I check relevant tutorials that may be affected by changes in this PR?
- [x] Did I clearly articulate why this PR was made the way it was and how it was made?

**Link to relevant issue(s)**

**How did you address these issues with this PR? What methods did you use?**
The type annotation in documentation for `get_position` on `Layers` [here](https://wikunia.github.io/Javis.jl/dev/references/#Javis.get_position-Tuple{Javis.Layer}) is a duplicate of the one for `Object` [here](https://wikunia.github.io/Javis.jl/dev/references/#Javis.get_position-Tuple{Object}).

This PR just changes 1 line to show the correct type annotation in the documentation.
