### PR TITLE
fix `` code in docstrings

### DIFF
--- a/src/shorthands/JCircle.jl
+++ b/src/shorthands/JCircle.jl
@@ -18,7 +18,7 @@ Draw a circle at `center` with the given `radius`
 # Keywords for all
 - `color` = "black"
 - `linewidth` = 1
-- `action::Symbol` :stroke by default can be ``:fill` or other actions explained in the Luxor documentation.
+- `action::Symbol` :stroke by default can be `:fill` or other actions explained in the Luxor documentation.
 
 Returns the center of the circle
 """

--- a/src/shorthands/JEllipse.jl
+++ b/src/shorthands/JEllipse.jl
@@ -31,7 +31,7 @@ Returns the center of the ellipse.
 # Keywords for all
 - `color` = "black"
 - `linewidth` = 1
-- `action::Symbol` :stroke by default can be ``:fill` or other actions explained in the Luxor documentation.
+- `action::Symbol` :stroke by default can be `:fill` or other actions explained in the Luxor documentation.
 """
 JEllipse(cpt::Point, w::Real, h::Real; color = "black", linewidth = 1, action = :stroke) =
     (


### PR DESCRIPTION
**How did you address these issues with this PR? What methods did you use?**
Twice ```` `` ````  was in the docstrings to start an inline code "block" which I changed to ```` ` ````


