### PR TITLE
Ignore the RFrames for the first Action

### DIFF
--- a/src/structs/Frames.jl
+++ b/src/structs/Frames.jl
@@ -66,7 +66,7 @@ function get_frames(parent, elem, frames::Symbol, last_frames::UnitRange; is_fir
 end
 
 """
-    get_frames(parent, elem, relative::RFrames, last_frames::UnitRange; is_first=falsee)
+    get_frames(parent, elem, relative::RFrames, last_frames::UnitRange; is_first=false)
 
 Return the frames based on a relative frames [`RFrames`](@ref) object and the `last_frames`.
 """
@@ -77,6 +77,10 @@ function get_frames(
     last_frames::UnitRange;
     is_first = false,
 )
+    # don't take the `last_frames` from the parent as this doesn't make sense
+    if is_first
+        return relative.frames
+    end
     start_frame = last(last_frames) + first(relative.frames)
     last_frame = last(last_frames) + last(relative.frames)
     return start_frame:last_frame

--- a/test/animations.jl
+++ b/test/animations.jl
@@ -76,7 +76,7 @@ end
     act!(red_ball, Action(anim_rotate_around(from_rot, to_rot, O)))
 
     blue_ball = Object(1:30, (args...) -> circ(O, "blue"), p2)
-    act!(blue_ball, Action(anim_rotate_around(to_rot, from_rot, red_ball)))
+    act!(blue_ball, Action(RFrames(1:30), anim_rotate_around(to_rot, from_rot, red_ball)))
     path_red = Object((video, args...) -> path!(path_of_red, get_position(red_ball), "red"))
     path_blue =
         Object(:same, (video, args...) -> path!(path_of_blue, pos(blue_ball), "blue"))

--- a/test/unit.jl
+++ b/test/unit.jl
@@ -288,6 +288,15 @@
         @test Javis.get_frames(obj1.actions[2]) == 6:10
     end
 
+    @testset "RFrames in first action" begin
+        video = Video(10, 10)
+        Background(1:20, (args...) -> 1)
+        a = Object(1:15, (args...) -> O) # 1:15
+        act!(a, Action(RFrames(1:3), appear(:fade))) # 1:3
+        render(video; tempdirectory = "images", pathname = "")
+        @test Javis.get_frames(a.actions[1]) == 1:3
+    end
+
     @testset "anim_" begin
         s = anim_scale(1, 2)
         @test s.from == Javis.Scale(1, 1)


### PR DESCRIPTION
## PR Checklist

If you are contributing to `Javis.jl`, please make sure you are able to check off each item on this list:

- [ ] Did I update `CHANGELOG.md` with whatever changes/features I added with this PR?
- [ ] Did I make sure to only change the part of the file where I introduced a new change/feature?
- [ ] Did I cover all corner cases to be close to 100% test coverage (if applicable)?
- [ ] Did I properly add Javis dependencies to the `Project.toml` + set an upper bound of the dependency (if applicable)?
- [ ] Did I properly add test dependencies to the `test` directory (if applicable)?
- [ ] Did I check relevant tutorials that may be affected by changes in this PR?
- [ ] Did I clearly articulate why this PR was made the way it was and how it was made?

**Link to relevant issue(s)**
Closes #335 


**How did you address these issues with this PR? What methods did you use?**
When the first Action of an Object uses `RFrames` it will be ignored as it is unexpected to error of being outside the frame range. 


