### PR TITLE
fix follow_path for objects with start_pos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - tutorial on partial draw / show creation 
 - Few tests for morphs added
 - test for partial draw/ show creation
+- fix for `follow_path` for objects with `start_pos` other than O
 
 ## v0.9.0 (26th of May 2022)
 - Ability to use Luxor functionality without rendering an animation

--- a/src/action_animations.jl
+++ b/src/action_animations.jl
@@ -416,9 +416,9 @@ function _follow_path(video, object, action, rel_frame, points; closed = closed)
     # if t is discrete and not 0.0 take the last point or first if closed
     if !isfirstframe && isapprox_discrete(t)
         if closed
-            translate(points[1])
+            translate(points[1] - object.start_pos)
         else
-            translate(points[end])
+            translate(points[end] - object.start_pos)
         end
         return
     end
@@ -426,16 +426,16 @@ function _follow_path(video, object, action, rel_frame, points; closed = closed)
     t -= floor(t)
     if isfirstframe
         # compute the distances only once for performance reasons
-        action.defs[:p_dist] = polydistances(points, closed = closed)
+        action.defs[:p_dist] = polydistances(points .- object.start_pos, closed = closed)
     end
     if isapprox(t, 0.0, atol = 1e-4)
-        translate(points[1])
+        translate(points[1] - object.start_pos)
         return
     end
     pdist = action.defs[:p_dist]
 
     overshootpoint = get_polypoint_at(points, t; pdist = pdist)
-    translate(overshootpoint)
+    translate(overshootpoint - object.start_pos)
 end
 
 """


### PR DESCRIPTION
## PR Checklist

If you are contributing to `Javis.jl`, please make sure you are able to check off each item on this list:

- [X] Did I update `CHANGELOG.md` with whatever changes/features I added with this PR?
- [X] Did I make sure to only change the part of the file where I introduced a new change/feature?
- [X] Did I cover all corner cases to be close to 100% test coverage (if applicable)?
- [X] Did I properly add Javis dependencies to the `Project.toml` + set an upper bound of the dependency (if applicable)?
- [X] Did I properly add test dependencies to the `test` directory (if applicable)?
- [X] Did I check relevant tutorials that may be affected by changes in this PR?
- [X] Did I clearly articulate why this PR was made the way it was and how it was made?

**Link to relevant issue(s)**
Closes #
https://github.com/JuliaAnimators/Javis.jl/issues/491


**How did you address these issues with this PR? What methods did you use?**
the points along which the objects should follow should have object.start_pos subtracted from them.


